### PR TITLE
feat: ondersteuning van de woordsoort

### DIFF
--- a/app/Actions/Articles/StoreArticleSuggestion.php
+++ b/app/Actions/Articles/StoreArticleSuggestion.php
@@ -8,8 +8,46 @@ use App\Data\SuggestionData;
 use App\Models\Article;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * StoreArticleSuggestion encapsulates the process of saving a new article suggestion.
+ *
+ * This action class accepts a SuggestionData data transfer object containing all the necessary information for an article suggestion.
+ * The workflow is executed within a database transaction to ensure that all operations succeed or fail together, preserving data consistency.
+ *
+ * The process involves:
+ * - Creating a new Article record using the suggestion data, excluding the 'regions' attribute.
+ * - Synchronizing the associated regions with the newly created article.
+ * - Optionally associating the article with an author if a creator_id is provided.
+ *
+ * Future developers extending or using this class should note that any modifications to the suggestion
+ * process should maintain transactional integrity, ensuring that a failure in any step will roll back the
+ * entire process.
+ *
+ * @package App\Actions\Articles
+ */
 final readonly class StoreArticleSuggestion
 {
+    /**
+     * Executes the suggestion storage workflow.
+     *
+     * This method performs the following steps within a single transaction:
+     *
+     * 1. Creates a new Article record with the data provided in the SuggestionData object, while explicitly excluding the
+     *    'regions' attribute. This ensures that the main article data is stored without interference from the region
+     *    associations.
+     *
+     * 2. Synchronizes the article's associated regions using the region IDs provided in the 'regions' field of the
+     *    SuggestionData. This establishes the many-to-many relationship between the article and its regions.
+     *
+     * 3. Checks if a creator_id is provided in the SuggestionData. If so, it associates the newly created article with
+     *    the specified author. This step binds the article to its creator for tracking and future reference.
+     *
+     * All these operations are wrapped within a database transaction. This design ensures that if any step fails, the
+     * transaction will roll back, keeping the database in a consistent state.
+     *
+     * @param SuggestionData $suggestionData The data transfer object carrying all details for the new article suggestion.
+     * @return void
+     */
     public function execute(SuggestionData $suggestionData): void
     {
         DB::transaction(function () use ($suggestionData): void {

--- a/app/Data/ArticleData.php
+++ b/app/Data/ArticleData.php
@@ -7,10 +7,34 @@ namespace App\Data;
 use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Data;
 
+/**
+ * ArticleData
+ *
+ * This Data Transfer Object (DTO) represents the structure of data related to an Article.
+ * It is used to encapsulate and transfer article information between different layers of the application, ensuring type safety and data consistency.
+ * Leveraging Spatie's Laravel Data package, this DTO simplifies data validation and transformation, especially when dealing with data received from HTTP requests.
+ *
+ * The class utilizes the `MapInputName` attribute to map incoming request parameters to the corresponding
+ * properties of this DTO, allowing for flexibility in naming conventions between the request and the internal
+ * data representation.
+ *
+ * @package App\Data
+ */
 final class ArticleData extends Data
 {
     /**
-     * @param array<int,string> $regions
+     * ArticleData constructor.
+     *
+     * Initializes a new ArticleData object, encapsulating the data required to represent an article.
+     * This constructor maps incoming data, typically from a request, to the object's properties, ensuring a consistent and type-safe representation of article information within the application.
+     * It leverages the `MapInputName` attribute to handle potential discrepancies between request parameter names and internal property names.
+     *
+     * @param string              $word                 The primary word or term associated with the article. This is a required field. Mapped from the 'woord' input name.
+     * @param string              $description          A detailed description or definition of the word. This is a required field. Mapped from the 'beschrijving' input name.
+     * @param string              $example              An example sentence or phrase demonstrating the usage of the word. This is a required field. Mapped from the 'voorbeeld' input name.
+     * @param array<int, string>  $regions              An array of region identifiers where the word is used or relevant. Defaults to an empty array if no regions are specified. Mapped from the 'regio' input name.
+     * @param string|null         $characteristics      Optional additional characteristics or notes about the word. Can be null if no additional characteristics are available. Mapped from the 'kenmerken' input name.
+     * @param int|null            $part_of_speech_id    Optional ID of the part of speech associated with the word. Can be null if the part of speech is not specified. Mapped from the 'woordsoort' input name.
      */
     public function __construct(
         #[MapInputName('woord')]        public string $word,

--- a/app/Data/ArticleData.php
+++ b/app/Data/ArticleData.php
@@ -18,5 +18,6 @@ final class ArticleData extends Data
         #[MapInputName('voorbeeld')]    public string $example,
         #[MapInputName('regio')]        public array $regions = [],
         #[MapInputName('kenmerken')]    public ?string $characteristics = null,
+        #[MapInputName('woordsoort')]   public ?int $part_of_speech_id = null,
     ) {}
 }

--- a/app/Data/SuggestionData.php
+++ b/app/Data/SuggestionData.php
@@ -1,14 +1,38 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Attributes\MapInputName;
 
-class SuggestionData extends Data
+/**
+ * SuggestionData
+ *
+ * This Data Transfer Object (DTO) encapsulates the data structure for a suggestion.
+ * It is used to represent and transfer suggestion information across the application, promoting type safety and data consistency.
+ * By utilizing Spatie's Laravel Data package, this DTO simplifies data validation and transformation, especially for data originating from HTTP requests.
+ * The `MapInputName` attribute is employed to map incoming request parameters to the corresponding DTO properties, providing flexibility in naming conventions.
+ *
+ * @package App\Data\Enums
+ */
+final class SuggestionData extends Data
 {
     /**
-     * @param array<int,string> $regions
+     * SuggestionData constructor.
+     *
+     * Initializes a new SuggestionData object, encapsulating the data necessary to represent a suggestion.
+     * This constructor maps incoming data, typically from a request, to the object's properties, ensuring a consistent and type-safe representation of suggestion information within the application.
+     * It leverages the `MapInputName` attribute to handle potential discrepancies between request parameter names and internal property names.
+     *
+     * @param string              $word               The primary word or term associated with the suggestion. This field is mandatory. Mapped from the 'woord' input name.
+     * @param string              $description        A comprehensive description or definition of the suggested word. This field is mandatory. Mapped from the 'beschrijving' input name.
+     * @param string              $example            An illustrative sentence or phrase showcasing the suggested word's usage. This field is mandatory. Mapped from the 'voorbeeld' input name.
+     * @param array<int, string>  $regions            An array of region identifiers where the suggested word is relevant or used. Defaults to an empty array if no specific regions are provided. Mapped from the 'regio' input name.
+     * @param string|null         $characteristics    Optional additional characteristics or notes about the suggested word. Can be null if no extra details are available. Mapped from the 'kenmerken' input name.
+     * @param int|null            $creator_id         Optional ID of the user who created the suggestion. Can be null if the creator is not specified. Mapped from the 'creator' input name.
+     * @param int|null            $part_of_speech_id  Optional ID of the part of speech associated with the suggested word. Can be null if the part of speech is not specified. Mapped from the 'woordsoort' input name.
      */
     public function __construct(
         #[MapInputName('woord')]        public string $word,

--- a/app/Data/SuggestionData.php
+++ b/app/Data/SuggestionData.php
@@ -17,5 +17,6 @@ class SuggestionData extends Data
         #[MapInputName('regio')]        public array $regions = [],
         #[MapInputName('kenmerken')]    public ?string $characteristics = null,
         #[MapInputName('creator')]      public ?int $creator_id = null,
+        #[MapInputName('woordsoort')]   public ?int $part_of_speech_id = null,
     ) {}
 }

--- a/app/Http/Controllers/Web/Articles/RequestArticleChangeController.php
+++ b/app/Http/Controllers/Web/Articles/RequestArticleChangeController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Web\Articles\DictionaryArticleController;
 use App\Http\Requests\Articles\UpdateArticleRequest;
 use App\Models\Region;
 use App\Models\Article;
+use App\Models\PartOfSpeech;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\RedirectResponse;
 use Spatie\RouteAttributes\Attributes\Get;
@@ -34,7 +35,7 @@ final readonly class RequestArticleChangeController
 {
     /**
      * Display the form for editing a specific word's definition.
-     * Retrieves available regions for a dropdown and the Article model instance.
+     * This method retrieves available regions and parts of speech for dropdown selection, and passes them along with the Article model instance to the edit view.
      *
      * @param  Article $word  The Article model instance to be edited (injected via route model binding).
      * @return Renderable     The view for editing the definition.
@@ -44,6 +45,7 @@ final readonly class RequestArticleChangeController
     {
         return view('definitions.update', [
             'regions' => Region::query()->pluck('name', 'id'),
+            'partOfSpeeches' => PartOfSpeech::query()->pluck('name', 'id'),
             'word' => $word
         ]);
     }

--- a/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
+++ b/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Web\Articles;
 
 use App\Actions\Articles\StoreArticleSuggestion;
 use App\Http\Requests\Articles\StoreSuggestionRequest;
+use App\Models\PartOfSpeech;
 use App\Models\Region;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\RedirectResponse;
@@ -35,7 +36,8 @@ final readonly class StoreArticleSuggestionController
     public function create(): Renderable
     {
         return view('definitions.create', [
-            'regions' => Region::query()->pluck('name', 'id')
+            'regions' => Region::query()->pluck('name', 'id'),
+            'partOfSpeeches' => PartOfSpeech::query()->pluck('name', 'id'),
         ]);
     }
 

--- a/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
+++ b/app/Http/Controllers/Web/Articles/StoreArticleSuggestionController.php
@@ -27,10 +27,10 @@ final readonly class StoreArticleSuggestionController
     /**
      * Displays the article submission form.
      *
-     * Prepares the creation view by loading all available regions for the dropdown selection.
-     * The regions are provided in a format suitable for form select elements, woth region names as labels and IDs as values.
+     * Prepares the creation view by loading all available regions and parts of speech for dropdown selection.
+     * The regions and parts of speech are provided in a format suitable for form select elements, with their names as labels and IDs as values.
      *
-     * @return Renderable  The form view for creating new dictionary entries
+     * @return Renderable The form view for creating new dictionary entries.
      */
     #[Get(uri: 'woordenboek-artikelen/insturen', name: 'definitions.create')]
     public function create(): Renderable

--- a/app/Http/Requests/Articles/StoreSuggestionRequest.php
+++ b/app/Http/Requests/Articles/StoreSuggestionRequest.php
@@ -28,6 +28,7 @@ final class StoreSuggestionRequest extends FormRequest
             'beschrijving' => ['required'],
             'regio' => ['required', 'array', 'min:1'],
             'voorbeeld' => ['required'],
+            'woordsoort' => [],
         ];
     }
 }

--- a/app/Http/Requests/Articles/StoreSuggestionRequest.php
+++ b/app/Http/Requests/Articles/StoreSuggestionRequest.php
@@ -8,17 +8,37 @@ use App\Data\SuggestionData;
 use Illuminate\Foundation\Http\FormRequest;
 use Spatie\LaravelData\WithData;
 
+/**
+ * StoreSuggestionRequest
+ *
+ * This class extends the FormRequest to validate and transform incoming data for creating a new suggestion.
+ * It utilizes Spatie's Laravel Data package for easy data transfer object (DTO) creation from request data.
+ *
+ * @package App\Http\Requests\Articles;
+ */
 final class StoreSuggestionRequest extends FormRequest
 {
-    /** @use WithData<SuggestionData> */
+    /**
+     * Trait to automatically convert the request data into a SuggestionData object.
+     *
+     * @use WithData<SuggestionData>
+     */
     use WithData;
 
+    /**
+     * The data class to use for automatic data conversion.
+     *
+     * @var string
+     */
     protected string $dataClass = SuggestionData::class;
 
     /**
      * Get the validation rules that apply to the request.
+     * 
+     * This method defines the validation rules for each field in the suggestion submission form.
+     * It ensures that required fields are present and that data types and lengths are appropriate.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string> An array of validation rules, where the keys are field names and the values are validation rules.
      */
     public function rules(): array
     {

--- a/resources/views/definitions/create.blade.php
+++ b/resources/views/definitions/create.blade.php
@@ -29,10 +29,28 @@
                 @endif
             </div>
 
-            <div class="form-group">
-                <label for="kenmerken" class="col-form-label">Kenmerken</label>
-                <input type="text" name="kenmerken" value=" {{ old('kenmerken') }}" id="kenmerkenHelpText" class="form-control">
-                <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Je kunt hier woordkenmerken aangeven, zoals het lidwoord, geslacht en meervoud van een zelfstandig naamwoord. Bijvoorbeeld: de ~ (v.), ~sen."/>
+            <div class="row">
+                <div class="form-group col-4">
+                    <label for="woordsoort" class="col-form-label">Woordsoort</label>
+
+                    <select name="woordsoort" id="woordsoort" class="form-select">
+                        <option value="">-- selecteer woordsoort --</option>
+
+                        @foreach ($partOfSpeeches as $partOfSpeech => $value)
+                            <option value="{{ $partOfSpeech }}" @selected(old('woordsoort') == $partOfSpeech)>
+                                {{ $value }}
+                            </option>
+                        @endforeach
+                    </select>
+
+                    <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Wat voor woord is het? Bv. zn, ww, bn."/>
+                </div>
+
+                <div class="form-group col-8">
+                    <label for="kenmerken" class="col-form-label">Kenmerken</label>
+                    <input type="text" name="kenmerken" value=" {{ old('kenmerken') }}" id="kenmerkenHelpText" class="form-control">
+                    <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Lidwoord, geslacht en meervoud – bv. de ~ (v.), ~sen."/>
+                </div>
             </div>
 
             <div class="form-group">
@@ -40,7 +58,7 @@
                 <textarea name="beschrijving" class="form-control @error('beschrijving') is-invalid @enderror" id="beschrijvingHelpText" cols="4">{{ old('beschrijving') }}</textarea>
 
                 @if ($errors->has('beschrijving'))
-                    <x-forms.validation-error field="kenmerken"/>
+                    <x-forms.validation-error field="beschrijving"/>
                 @else
                     <x-forms.help-text icon="true" field="beschrijvingHelpText" text="Beschrijf de term in Algemeen Beschaafd Vlaams en beperk je tot één betekenis per beschrijving. Voeg andere betekenissen apart toe."/>
                 @endif

--- a/resources/views/definitions/update.blade.php
+++ b/resources/views/definitions/update.blade.php
@@ -37,10 +37,28 @@
                     @endif
                 </div>
 
-                <div class="form-group">
-                    <label for="kenmerken" class="col-form-label">Kenmerken</label>
-                    <input type="text" name="kenmerken" value=" {{ old('kenmerken', $word->characteristics) }}" id="kenmerkenHelpText" class="form-control">
-                    <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Je kunt hier woordkenmerken aangeven, zoals het lidwoord, geslacht en meervoud van een zelfstandig naamwoord. Bijvoorbeeld: de ~ (v.), ~sen."/>
+                <div class="row">
+                    <div class="form-group col-4">
+                        <label for="woordsoort" class="col-form-label">Woordsoort</label>
+
+                        <select name="woordsoort" id="woordsoort" class="form-select">
+                            <option value="">-- selecteer woordsoort --</option>
+
+                            @foreach ($partOfSpeeches as $partOfSpeech => $value)
+                                <option value="{{ $partOfSpeech }}" @selected(old('woordsoort') == $partOfSpeech)>
+                                    {{ $value }}
+                                </option>
+                            @endforeach
+                        </select>
+
+                        <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Wat voor woord is het? Bv. zn, ww, bn."/>
+                    </div>
+
+                    <div class="form-group col-8">
+                        <label for="kenmerken" class="col-form-label">Kenmerken</label>
+                        <input type="text" name="kenmerken" value=" {{ old('kenmerken') }}" id="kenmerkenHelpText" class="form-control">
+                        <x-forms.help-text field="kenmerkenHelpText" icon="true" text="Lidwoord, geslacht en meervoud – bv. de ~ (v.), ~sen."/>
+                    </div>
                 </div>
 
                 <div class="form-group">


### PR DESCRIPTION
In deze pull request word er de ondersteuning van de woordsoort toegevoegd in het suggestie formulier. Dit veld is optioneel wegens dat gebruikers niet familiar kunnen zijn met woordsoorten. Maar het opgegeven van een woordsoort toch een redeacteur kan helpen in het redactie proces van een artikel.