### PR TITLE
fix: Implementeren van 4 eyes principe bij het goedkeuren/afkeuren van artikelen

### DIFF
--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -52,35 +52,64 @@ final readonly class ArticlePolicy
     }
 
     /**
-     * Determines whether a user can reject a publication proposal.
+     * Determines whether a user can reject an article that was submitted for publication.
      *
-     * Rejection authority is limited to administrators and chief editors, and can only applies to articles in the Approval state.
-     * This ensures that rejection decisions come from appropriately senior editor.
+     * This policy enforces two key requirements for rejection:
+     * - The article must be in the Approval state, indicating it has been submitted for review
+     * - Only administrators and chief editors have the authority to reject articles
      *
-     * @param  User     $user     The user that is attempting to reject an article.
-     * @param  Article  $article  The article that is being rejected
-     * @return bool               True is the user has permission to reject the article, false otherwise
+     * Additionally, the policy implements a four-eyes principle:
+     * - The article must have an assigned editor
+     * - The user rejecting cannot be the same person as the assigned editor
+     *
+     * This ensures that rejection decisions are made with appropriate oversight
+     * and maintains separation between article editing and approval processes.
+     *
+     * @param  User     $user     The user attempting to reject the article
+     * @param  Article  $article  The article being considered for rejection
+     * @return bool              True if the user has permission to reject, false otherwise
      */
     public function rejectPublication(User $user, Article $article): bool
     {
-        return $article->state->is(enum: ArticleStates::Approval)
-            && $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::EditorInChief]);
+        $editorRelation = $article->editor();
+
+        if (
+            $article->state->isNot(enum: ArticleStates::Approval)
+            && $user->user_type->notIn(enums: [UserTypes::EditorInChief, UserTypes::Administrators, UserTypes::Developer])
+        ) {
+            return false;
+        }
+
+        return $editorRelation->exists() && $editorRelation->isNot($user);
     }
 
     /**
      * Determines whether a user can publish an article.
      *
-     * Publication authority is restricted to administrators and chief editors, applying to articles in either Approval of Archived states.
-     * This ensures high-level oversight of content that becomes publicy visible.
+     * Publication is only allowed when:
+     * - The article is in either Approval or Archived state
+     * - The article has an assigned editor
+     * - The publishing user is not the assigned editor (four-eyes principle)
      *
-     * @param  User     $user     The user that is attempting to publish the article.
-     * @param  Article  $article  The article that is being published
-     * @return bool               True if the user has the permission to publish the article, false otherwiser
+     * This policy ensures proper oversight of content publication by requiring review from someone other than the original editor.
+     * This helps maintain quality standards and prevents self-publication of content.
+     *
+     * @param  User     $user     The user attempting to publish the article
+     * @param  Article  $article  The article to be published
+     * @return bool               True if publication is allowed, false otherwise
      */
     public function publishArticle(User $user, Article $article): bool
     {
-        return $article->state->in(enums: [ArticleStates::Approval, ArticleStates::Archived])
-            && $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::EditorInChief]);
+        $editorRelation = $article->editor();
+
+        if (
+            $article->state->notIn(enums: [ArticleStates::Approval, ArticleStates::Archived]) &&
+            $user->user_type->notIn(enums: [UserTypes::EditorInChief, UserTypes::Administrators, UserTypes::Developer])
+        ) {
+            return false;
+        }
+
+        return $editorRelation->exists() && $editorRelation->isNot($user);
     }
 
     /**


### PR DESCRIPTION
Deze pull request verhinderd dat de zelde persoon een gewijzigd artikel kan goedkeuren/afkeuren voor publicatie. 
Echter blijft het hoofd principe van kracht dat een redacteur geen artikelen kan goedkeuren. Maar de wijziginging zit hem erin dat nu eindredacteurs, administrators, ontwikkelaars hun eigen gewijzigde artikelen niet kunnen goedkeuren maar een andere bevoegde gebruiker nodig hebben om de handeling uit te voeren. 