### PR TITLE
Refactor: Rate Limiting naar herbruikbare Trait met gebruikerspecifieke limieten

### DIFF
--- a/app/Concerns/RateLimitSubmission.php
+++ b/app/Concerns/RateLimitSubmission.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns;
+
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\RateLimiter;
+
+trait RateLimitSubmission
+{
+    protected int $guestMaxSubmissionAttempts = 15;
+    protected int $loggedInMaxSubmissionAttempts = 45;
+
+    protected function attemptSubmissionWithRateLimiting(FormRequest $request, string $key,  Closure $callback)
+    {
+        $rateLimitKey = $this->configureRateLimitingKey($key, $request);
+
+        if (RateLimiter::tooManyAttempts($rateLimitKey, $this->maxAttempts())) {
+            flash('Het lijkt erop dat je te veel suggesties probeerd toe te voegen op een te korte tijd. Probeer het later nog eens', 'alert-danger');
+            return back();
+        }
+
+        RateLimiter::increment($rateLimitKey);
+
+        return $callback();
+    }
+
+    private function maxAttempts(): int
+    {
+        return auth()->check()
+            ? $this->loggedInMaxSubmissionAttempts
+            : $this->guestMaxSubmissionAttempts;
+    }
+
+    private function configureRateLimitingKey(string $key, FormRequest $formRequest): string
+    {
+        return $key . ':' . (auth()->check()
+            ? auth()->id()
+            : $formRequest->ip());
+    }
+}


### PR DESCRIPTION
**Beschrijving:**

Deze pull request introduceert een nieuwe trait, `RateLimitsSubmissions`, om de rate limiting logica voor het indienen van suggesties te vereenvoudigen en te centraliseren.

* Rate limiting logica verplaatst naar de `RateLimitsSubmissions` trait.
* Ondersteuning toegevoegd voor verschillende limieten voor gasten (via IP-adres) en ingelogde gebruikers (via ID).
* Limieten configureerbaar via `$guestMaxSubmissionAttempts` en `$loggedInMaxSubmissionAttempts` properties in de controller.
* Bugfix: Correcte verwerking van de maximum aantal pogingen.

**Voordelen:**

* Code is herbruikbaar voor andere functionaliteiten.
* Eenvoudiger om limieten per gebruikersgroep in te stellen.
* Betere code-organisatie en leesbaarheid.

**Testplan:**

* Test of gasten na de limiet een melding krijgen.
* Test of ingelogde gebruikers na hun (mogelijk hogere) limiet een melding krijgen.
* Controleer of de configuratie in de controller werkt.

Deze wijziging maakt de rate limiting implementatie duidelijker en flexibeler.