### PR TITLE
Toevoegen van een actie om de publicatie van artikelen ongedaan te maken. 

### DIFF
--- a/app/Builders/ArticleBuilder.php
+++ b/app/Builders/ArticleBuilder.php
@@ -6,6 +6,7 @@ namespace App\Builders;
 
 use App\Enums\ArticleStates;
 use App\Enums\Visibility;
+use App\Models\Note;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use JetBrains\PhpStorm\Deprecated;
@@ -55,6 +56,14 @@ final class ArticleBuilder extends Builder
             $this->model->update(attributes: ['state' => ArticleStates::Published, 'archiving_reason' => null, 'published_at' => now(), 'archived_at' => null]);
             $this->model->archiever()->associate(null)->save();
         });
+    }
+
+    public function attachNote(string $title, ?string $note = null): self
+    {
+        $note = new Note(attributes: ['title' => $title, 'author_id' => auth()->id(), 'body' => $note]);
+        $this->model->notes()->save(model: $note);
+
+        return $this;
     }
 
     public function isHidden(): bool

--- a/app/Filament/Resources/ArticleResource/Actions/RemoveEditorAction.php
+++ b/app/Filament/Resources/ArticleResource/Actions/RemoveEditorAction.php
@@ -72,6 +72,7 @@ final class RemoveEditorAction extends Action
 
         $this->requiresConfirmation();
         $this->modalWidth(MaxWidth::Large);
+
         $this->modalCloseButton(false);
         $this->modalIcon(self::$navigationIcon);
         $this->modalHeading($this->getCustomUserBasedModalHeading());

--- a/app/Filament/Resources/ArticleResource/Actions/RevokePublication.php
+++ b/app/Filament/Resources/ArticleResource/Actions/RevokePublication.php
@@ -6,7 +6,11 @@ namespace App\Filament\Resources\ArticleResource\Actions;
 
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Forms\Components\Textarea;
 
+/**
+ * @property \App\Models\Article $record The dictionary article being submitted for publication
+ */
 final class RevokePublication extends Action
 {
     use CanCustomizeProcess;
@@ -26,9 +30,31 @@ final class RevokePublication extends Action
         $this->color('danger');
 
         $this->requiresConfirmation();
+
         $this->modalIcon('tabler-arrow-back-up');
+        $this->modalCloseButton(false);
         $this->modalHeading('Publicatie ongedaan maken');
         $this->modalDescription('Bij het ongemaken van een publicatie zal het artikel niet meer raadpleegbaar zijn voor gebruikers. Dit kan handig zijn voor een herwerking van het artikel.');
+        $this->modalSubmitActionLabel('Ongedaan maken');
 
+        $this->form([
+            Textarea::make('reason')
+                ->label('Reden van de handeling')
+                ->placeholder('Beschrijf kort waarom je de publicatie ongedaan wilt maken.')
+                ->rows(5)
+                ->required()
+        ]);
+
+        $this->successNotificationTitle('Publicatie ongedaan gemaakt');
+        $this->failureNotificationTitle('Helaas pindakaas! Er is iets migelopen.');
+
+        $this->action(function (): void {
+            if ($this->process(fn (array $data): bool => $this->record->articleStatus()->transitionToEditing($data['reason']))) {
+                $this->success();
+                return;
+            }
+
+            $this->failure();
+        });
     }
 }

--- a/app/Filament/Resources/ArticleResource/Actions/RevokePublication.php
+++ b/app/Filament/Resources/ArticleResource/Actions/RevokePublication.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ArticleResource\Actions;
+
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+
+final class RevokePublication extends Action
+{
+    use CanCustomizeProcess;
+
+    public static function getDefaultName(): ?string
+    {
+        return trans('ongedaan maken');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->authorize('unpublish', $this->record);
+
+        $this->icon('tabler-arrow-back-up');
+        $this->color('danger');
+
+        $this->requiresConfirmation();
+        $this->modalIcon('tabler-arrow-back-up');
+        $this->modalHeading('Publicatie ongedaan maken');
+        $this->modalDescription('Bij het ongemaken van een publicatie zal het artikel niet meer raadpleegbaar zijn voor gebruikers. Dit kan handig zijn voor een herwerking van het artikel.');
+
+    }
+}

--- a/app/Filament/Resources/ArticleResource/Pages/ViewWord.php
+++ b/app/Filament/Resources/ArticleResource/Pages/ViewWord.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\ArticleResource\Pages;
 
 use App\Filament\Resources\ArticleResource;
+use App\Filament\Resources\ArticleResource\Actions\RevokePublication;
 use App\Filament\Resources\ArticleResource\Actions\States as ArticleStateActions;
 use Filament\Actions as FilamentActions;
 use Filament\Actions\ActionGroup;
@@ -51,11 +52,12 @@ final class ViewWord extends ViewRecord
             ActionGroup::make([
                 ArticleStateActions\AcceptPublishingProposal::make(),
                 ArticleStateActions\RejectPublishingAction::make(),
+                RevokePublication::make(),
             ])
             ->color('gray')
             ->icon('tabler-world-upload')
             ->label('Publicatie')
-            ->authorize('publish', $this->record)
+            ->authorizeAny(['publish', 'unpublish'], $this->record)
             ->button(),
 
             ArticleStateActions\UnarchiveAction::make(),

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -32,7 +32,9 @@ final readonly class ArticlePolicy
      */
     public function update(User $user, Article $article): bool
     {
-        if ($article->state->is(ArticleStates::Approval) && $user->user_type->in([UserTypes::EditorInChief, UserTypes::Administrators, UserTypes::Developer])) {
+        $isPublishedOrAwaitinApproval = ($article->isPublished() || $article->state->is(ArticleStates::Approval)) ;
+
+        if ($isPublishedOrAwaitinApproval && $user->user_type->in([UserTypes::EditorInChief, UserTypes::Administrators, UserTypes::Developer])) {
             return true;
         }
 
@@ -82,6 +84,11 @@ final readonly class ArticlePolicy
         }
 
         return $article->editor()->exists() && $article->editor()->isNot($user);
+    }
+
+    public function unpublish(User $user, Article $article): bool
+    {
+        return $article->isPublished() && $user->user_type->in(enums: [UserTypes::Developer, UserTypes::Administrators]);
     }
 
     /**

--- a/app/States/Articles/ApprovalState.php
+++ b/app/States/Articles/ApprovalState.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\States\Articles;
 
 use App\Enums\ArticleStates;
-use App\Models\Note;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -27,12 +26,8 @@ final class ApprovalState extends ArticleState
     public function transitionToEditing(?string $reason = null): bool
     {
         return DB::transaction(function () use ($reason): bool {
-            if (! $this->article->update(attributes: ['state' => ArticleStates::Draft])) {
-                return false;
-            }
-
-            $note = new Note(attributes: ['title' => 'Voorstellen tot wijziging', 'author_id' => auth()->id(), 'body' => $reason]);
-            $this->article->notes()->save(model: $note);
+            $this->article->update(attributes: ['state' => ArticleStates::Draft]);
+            $this->article->attachNote(title: 'Voorstellen tot wijziging', note: $reason);
 
             return true;
         });


### PR DESCRIPTION
Met deze Pull Request voegen we de functionaliteit toe om artikelen in de publicatie fase te bewerken voor kleine edits. Indien er een grondiger onderhoud nodig is kan een Administrator en of Developer de publicatie van het artikel intrekken. 

Als logisch gevolg word deze het artikel terug geplaatst naar een drft status en word enkel de state naar draft gezet en de publicatie gegevens verwijderd. Als ook word in de confirmatie dialoog om een beweegredenen gevraagd. Deze word als interne notitie aan het artikel gekoppeld. 

CC @Georges-Grootjans @Taalmiet Indien jullie nog opmerkingen/vragen hebben over deze implementatie aarzel me dan niet om via Discord een DM te sturen of een tread te starten in de server. 
