### PR TITLE
Fix 154: Mogelijkheid om artikelen zachtaardig te verwijderen

### DIFF
--- a/app/Filament/Resources/ArticleResource.php
+++ b/app/Filament/Resources/ArticleResource.php
@@ -243,6 +243,15 @@ final class ArticleResource extends Resource
             ]);
     }
 
+    /**
+     * Modifies the Eloquent query to exclude soft deleted articles for non-editor users.
+     *
+     * This method overrides the default Eloquent query to remove the global scope that automatically excludes soft-deleted records.
+     * This allows administrators and other privileged users to see soft-deleted articles in the list.
+     * Editor and EditorInChief users will see all records.
+     *
+     * @return Builder<Article> The modified Eloquent query builder.
+     */
     public static function getEloquentQuery(): Builder
     {
         if (auth()->user()->user_type->in(enums: [UserTypes::Editor, UserTypes::EditorInChief])) {
@@ -250,7 +259,7 @@ final class ArticleResource extends Resource
         }
 
         return parent::getEloquentQuery()
-            ->withoutGlobalScopes([SoftDeletingScope::class,]);
+            ->withoutGlobalScopes([SoftDeletingScope::class]);
     }
 
     /**

--- a/app/Filament/Resources/ArticleResource.php
+++ b/app/Filament/Resources/ArticleResource.php
@@ -11,6 +11,7 @@ use App\Filament\Resources\ArticleResource\Schema\WordInfolist;
 use App\Filament\Resources\ArticleResource\Pages;
 use App\Filament\Resources\ArticleResource\Schema\FormSchema;
 use App\Models\Article;
+use App\UserTypes;
 use Filament\Tables\Actions\Action;
 use Filament\Forms\Form;
 use Filament\Infolists\Infolist;
@@ -244,10 +245,12 @@ final class ArticleResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
+        if (auth()->user()->user_type->in(enums: [UserTypes::Editor, UserTypes::EditorInChief])) {
+            return parent::getEloquentQuery();
+        }
+
         return parent::getEloquentQuery()
-            ->withoutGlobalScopes([
-                SoftDeletingScope::class,
-            ]);
+            ->withoutGlobalScopes([SoftDeletingScope::class,]);
     }
 
     /**

--- a/app/Filament/Resources/ArticleResource.php
+++ b/app/Filament/Resources/ArticleResource.php
@@ -22,10 +22,12 @@ use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 /**
  * Class ArticleResource
@@ -217,6 +219,7 @@ final class ArticleResource extends Resource
             ->actions([
                 Tables\Actions\ViewAction::make()->hiddenLabel(),
                 Tables\Actions\EditAction::make()->hiddenLabel(),
+                Tables\Actions\RestoreAction::make()->hiddenLabel()->color('danger'),
                 Tables\Actions\DeleteAction::make()->hiddenLabel(),
             ])
             ->filters([
@@ -224,6 +227,9 @@ final class ArticleResource extends Resource
                     ->label('status')
                     ->multiple()
                     ->options(ArticleStates::class),
+                TrashedFilter::make()
+                    ->native(false)
+                    ->visible(fn (Article $article): bool => auth()->user()->canAny(['restore', 'restoreAny'], $article)),
                 Filter::make('assigned')
                     ->label('Toegewezen aan mij')
                     ->query(fn (Builder $query): Builder => $query->where('editor_id', auth()->id())),
@@ -231,7 +237,16 @@ final class ArticleResource extends Resource
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
                 ]),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
             ]);
     }
 
@@ -244,7 +259,7 @@ final class ArticleResource extends Resource
      */
     private static function selectDatabaseColumns(Builder $builder): Builder
     {
-        return $builder->addSelect('id', 'characteristics', 'part_of_speech_id', 'word', 'state', 'author_id', 'created_at', 'updated_at');
+        return $builder->addSelect('id', 'characteristics', 'part_of_speech_id', 'word', 'state', 'author_id', 'created_at', 'updated_at', 'deleted_at');
     }
 
     /**

--- a/app/Filament/Resources/ArticleResource/Pages/EditWord.php
+++ b/app/Filament/Resources/ArticleResource/Pages/EditWord.php
@@ -62,6 +62,7 @@ final class EditWord extends EditRecord
             PublishArticleAction::make(),
             Actions\DeleteAction::make()
                 ->icon('heroicon-o-trash'),
+            Actions\RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
         ];
     }
 

--- a/app/Filament/Resources/ArticleResource/Pages/ListWords.php
+++ b/app/Filament/Resources/ArticleResource/Pages/ListWords.php
@@ -49,17 +49,4 @@ final class ListWords extends ListRecords
     {
         return [ArticleRegistrationChart::class];
     }
-
-    /**
-     * Page Initialization Handler
-     *
-     * Performs the initial setup of the page state during component mounting.
-     * This process involves restoring any previously selected tab from the session storage.
-     * When no prior selection exists, the system falls back to a predefined default tab.
-     */
-    public function mount(): void
-    {
-        parent::mount();
-        $this->activeTab = (string) session('currentArticleTab', $this->getDefaultActiveTab());
-    }
 }

--- a/app/Filament/Resources/ArticleResource/Pages/ViewWord.php
+++ b/app/Filament/Resources/ArticleResource/Pages/ViewWord.php
@@ -64,6 +64,7 @@ final class ViewWord extends ViewRecord
 
             ArticleStateActions\UnarchiveAction::make(),
             FilamentActions\DeleteAction::make()->icon('heroicon-o-trash'),
+            FilamentActions\RestoreAction::make()->icon('heroicon-m-arrow-uturn-left'),
         ];
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -47,6 +47,7 @@ use Kenepa\ResourceLock\Models\Concerns\HasLocks;
  * @property int|null       $part_of_speech_id  The unique ID of the part of speech information.
  * @property string |null   $archiving_reason   The reason why the article has been archived.
  * @property \Carbon\Carbon $archived_at        Timestamp for when the article is archived at
+ * @property \Carbon\Carbon $deleted_at         Timestamp for when the article is marked for deletion.
  * @property \Carbon\Carbon $created_at         Timestamp of when the article was created
  * @property \Carbon\Carbon $updated_at         Timestamp of the last update
  *
@@ -247,6 +248,14 @@ final class Article extends Model implements AuditableContract
         ];
     }
 
+    /**
+     * Defines the query for prunable records.
+     *
+     * This method configures the query to select soft-deleted articles that have been deleted for more then two months.
+     * These articles are considered prunable and can be permanently removed from the database.
+     *
+     * @return Builder The query builder instance for prunable articles.
+     */
     public function prunable(): Builder
     {
         return static::where('deleted_at', '<=', now()->subMonths(2));

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Overtrue\LaravelLike\Traits\Likeable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -58,6 +59,7 @@ final class Article extends Model implements AuditableContract
     use Auditable;
     use Likeable;
     use HasLocks;
+    use SoftDeletes;
 
     /**
      * Specifies attributes that are protected from mass assignment.

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -12,8 +12,10 @@ use App\Enums\DataOrigin;
 use App\Enums\LanguageStatus;
 use App\Models\Relations\BelongsToEditor;
 use App\Models\Relations\BelongsToManyRegions;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -60,6 +62,7 @@ final class Article extends Model implements AuditableContract
     use Likeable;
     use HasLocks;
     use SoftDeletes;
+    use Prunable;
 
     /**
      * Specifies attributes that are protected from mass assignment.
@@ -242,5 +245,10 @@ final class Article extends Model implements AuditableContract
             'status' => LanguageStatus::class,
             'sources' => 'array',
         ];
+    }
+
+    public function prunable(): Builder
+    {
+        return static::where('deleted_at', '<=', now()->subMonths(2));
     }
 }

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -163,4 +163,14 @@ final readonly class ArticlePolicy
         return $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::EditorInChief])
             && $article->state->in(enums: [ArticleStates::New, ArticleStates::Draft, ArticleStates::ExternalData]);
     }
+
+    public function restore(User $user): bool
+    {
+        return $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::Developer]);
+    }
+
+    public function restoreAny(User $user): bool
+    {
+        return $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::Developer]);
+    }
 }

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -160,7 +160,7 @@ final readonly class ArticlePolicy
      */
     public function delete(User $user, Article $article): bool
     {
-        return $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::EditorInChief])
+        return $user->user_type->in(enums: [UserTypes::Administrators, UserTypes::Developer])
             && $article->state->in(enums: [ArticleStates::New, ArticleStates::Draft, ArticleStates::ExternalData]);
     }
 

--- a/database/migrations/2025_02_10_131512_create_articles_table.php
+++ b/database/migrations/2025_02_10_131512_create_articles_table.php
@@ -46,6 +46,7 @@ return new class extends Migration
             $table->json('sources')->nullable();
             $table->timestamp('archived_at')->nullable();
             $table->timestamp('published_at')->nullable();
+            $table->softDeletes();
             $table->timestamps();
         });
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('ban:delete-expired')->everyMinute();
-Schedule::command('modal:prune')->daily();
+Schedule::command('modal:prune')->daily()->at('02:00');
 Schedule::command('backup:clean')->daily()->at('01:00');
 Schedule::command('backup:run')->daily()->at('01:30');
 Schedule::command('backup:monitor')->daily()->at('03:00');

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('ban:delete-expired')->everyMinute();
+Schedule::command('modal:prune')->daily();
 Schedule::command('backup:clean')->daily()->at('01:00');
 Schedule::command('backup:run')->daily()->at('01:30');
 Schedule::command('backup:monitor')->daily()->at('03:00');


### PR DESCRIPTION
IN deze Pull request voegen we de functionaliteit toe om artikelen zachtaardig te verwijderen in het Vlaams woordenboek. 
Het gaat als volgt te werk. Een Administrator of Ontwikkelaar kan een artikel markeren voor verwijderen als het artikel een van de volgende states draagt: Suggestie, Klad Versie, Externe data (vw 1.0 artikelen). 

Indien men een artikel verwijderd is het gemarkeerd als verwijderen. En kunnen enkel administrators en of Ontwikkelaars de artikelen bekijken als men gebruikt maakt van de geimplementeerde filter. 

Indien deze filter actief is kunnen ook enkel zij de artikels herstellen om de verwijdering ongedaan te maken. Na de markering voor verwijdering zal de applicatie automatisch na datum de artikelen definitief verwijderen. 

(Feedback omtrent deze implementatie is altijd welkom.)
