### PR TITLE
Implement notificatie mail voor artikel pruning

### DIFF
--- a/app/Console/Commands/Reminders/PruneArticlesReminderCommand.php
+++ b/app/Console/Commands/Reminders/PruneArticlesReminderCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Reminders;
+
+use App\Models\Article;
+use App\Models\User;
+use App\Notifications\Reminders\PruneArticleNotification;
+use App\UserTypes;
+use Illuminate\Console\Command;
+
+final class PruneArticlesReminderCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'notify:article-prune-reminder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send a one-time reminder to admins/developers before pruning articles';
+
+    protected $hidden = true;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $pruneDate = now()->subDays(60);
+        $reminderThreshold = now()->subDays(58);
+
+        $articlesToPrune = Article::query()
+            ->onlyTrashed()
+            ->whereDate('deleted_at', '<=', $reminderThreshold)
+            ->whereDate('deleted_at', '>=', $pruneDate)
+            ->whereNull('prune_reminder_sent_at')
+            ->get();
+
+        if ($articlesToPrune->isEmpty()) {
+            $this->info('No articles to remind about.');
+            return;
+        }
+
+        $articlesToPrune->each(function (Article $article): void {
+            $article ->update(['prune_reminder_sent_at' => now()]);
+        });
+
+        User::where('user_type', UserTypes::Administrators)
+            ->orWhere('user_type', UserTypes::Developer)
+            ->each(function (User $user) use ($articlesToPrune) {
+                $user->notify(new PruneArticleNotification($articlesToPrune));
+            });
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -258,6 +258,6 @@ final class Article extends Model implements AuditableContract
      */
     public function prunable(): Builder
     {
-        return static::where('deleted_at', '<=', now()->subMonths(2));
+        return static::where('deleted_at', '<=', now()->subDays(60));
     }
 }

--- a/app/Notifications/Reminders/PruneArticleNotification.php
+++ b/app/Notifications/Reminders/PruneArticleNotification.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Notifications\Reminders;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class PruneArticleNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        protected Collection $articles,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject('Herinnering: Woordenboekartikelen worden binnen 2 dagen definitief verwijderd')
+            ->greeting('Beste ' . $notifiable->name . ',')
+            ->line('De volgende woordenboekartikelen zijn eerder verwijderd en worden **binnen 2 dagen automatisch en permanent verwijderd**:')
+            ->line('');
+
+        foreach ($this->articles as $article) {
+            $mail->line("**#{$article->id}** - {$article->word}, *(verwijderd op: {$article->deleted_at->format('d/m/Y')})*");
+        }
+
+        $mail->line('')
+            ->line('Als deze artikelen behouden moeten blijven, gelieve tijdig actie te ondernemen.')
+            ->line('Deze herinnering wordt slechts éénmalig verzonden.');
+
+        return $mail;
+    }
+}

--- a/database/migrations/2025_02_10_131512_create_articles_table.php
+++ b/database/migrations/2025_02_10_131512_create_articles_table.php
@@ -46,6 +46,7 @@ return new class extends Migration
             $table->json('sources')->nullable();
             $table->timestamp('archived_at')->nullable();
             $table->timestamp('published_at')->nullable();
+            $table->timestamp('prune_reminder_sent_at')->nullable();
             $table->softDeletes();
             $table->timestamps();
         });

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('ban:delete-expired')->everyMinute();
 Schedule::command('modal:prune')->daily()->at('02:00');
+Schedule::command('model:prune')->dailyAt('00:45');
 Schedule::command('backup:clean')->daily()->at('01:00');
 Schedule::command('backup:run')->daily()->at('01:30');
 Schedule::command('backup:monitor')->daily()->at('03:00');


### PR DESCRIPTION
We hebben nu het systeem voor soft deletes op de artikelen volledig geimplementeerd. De volgende stap was dat er een email notificatie komt voor het informeren van ontwikkelaars en administrators omtrent de zaken die hier staan te gebeuren. 

Elk artikel zal automatisch verwijderd na 60 dagen. En met deze pull request krijgen administrators en ontwikkelaars een herrineringsmail. Die het er als volgt uitziet. 

![image](https://github.com/user-attachments/assets/8fe78fbc-d700-4bc7-aa80-feb65694864d)
