### PR TITLE
fix; implementatie van ArticlePolicy duplicatie-logica en status validatie

### DIFF
--- a/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
@@ -32,7 +32,7 @@ final class DuplicationArticleAction extends Action
         $this->color('gray');
         $this->label('Dupliceren');
 
-        $this->hidden(fn (Article $article): bool => $article->trashed());
+        $this->authorize('duplicate');
 
         $this->requiresConfirmation();
         $this->modalIcon(Heroicon::OutlinedDocumentDuplicate);

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -137,6 +137,40 @@ final class ArticlePolicy
     }
 
     /**
+     * Determines whether the user can create a copy of an existing article.
+     *
+     * Duplication is permitted for articles in 'Kladversie', 'Publicatie', or 'Archief' states.
+     *
+     * This allows editors to:
+     * 1. Create safety backups of complex drafts.
+     * 2. Prepare new revisions of currently published entries without affecting the live site.
+     * 3. Repurpose archived data as a starting point for new lemmas.
+     *
+     * @param  User    $user     The user attempting to duplicate the article.
+     * @param  Article $article  The source article to be copied.
+     * @return Response
+     */
+    public function duplicate(User $user, Article $article): Response
+    {
+        $cloneableStates = [ArticleStates::Published, ArticleStates::Draft, ArticleStates::Archived];
+
+        if ($article->trashed()) {
+            return Response::deny(message: __('Je kan geen verwijderd artikel dupliceren.'));
+        }
+
+        if ($article->state->notIn(enums: $cloneableStates)) {
+            return Response::deny(message: __('Artikelen in de status :state kunnen niet worden gedepliceerd.', [
+                'state' => $article->state->getLabel()
+            ]));
+        }
+
+
+        return $user->can('create:article')
+            ? Response::allow()
+            : Response::deny('Je hebt geen rechten om nieuwe artikelen aan te maken.');
+    }
+
+    /**
      * Determines whether a user can publish an article.
      *
      * Publication is only allowed when:

--- a/app/Policies/ThreadPolicy.php
+++ b/app/Policies/ThreadPolicy.php
@@ -12,7 +12,7 @@ use Illuminate\Auth\Access\Response;
 /**
  * Defines the comprehensive authorization rules for all interactions within a private messaging thread.
  * This policy enforces strict privacy rules and delegates management responsibilities based on the user's relationship to the thread (Participant vs. Creator).
- * 
+ *
  * @package App\Policies
  */
 final readonly class ThreadPolicy
@@ -24,7 +24,7 @@ final readonly class ThreadPolicy
      * - The user **MUST** be a current participant in the thread.
      *
      * Rationale:
-     * This is a fundamental privacy mechanism. If a user is not listed as a member, they cannot see the thread's content or confirm its existence. 
+     * This is a fundamental privacy mechanism. If a user is not listed as a member, they cannot see the thread's content or confirm its existence.
 	 * Unauthorized attempts result in a "404 Not Found" response (`denyAsNotFound`) to prevent malicious users from confirming that a thread ID is valid but inaccessible.
      *
      * @param  User   $user    The user attempting the action.
@@ -33,13 +33,11 @@ final readonly class ThreadPolicy
      */
     public function view(User $user, Thread $thread): Response
 	{
-		if ($thread->hasParticipant($user->id)) {
-			return Response::allow();
-		}
-		
-		return Response::denyAsNotFound();
+	    return $thread->hasParticipant($user->id)
+            ? Response::allow()
+            : Response::denyAsNotFound();
 	}
-	
+
 	/**
      * Determines whether the user can send a new message (reply) to the thread.
      *
@@ -56,22 +54,20 @@ final readonly class ThreadPolicy
      */
 	public function reply(User $user, Thread $thread): Response
 	{
-		if ($thread->hasParticipant($user->id)) {
-			return Response::allow();
-		}
-		
-		return Response::denyAsNotFound();
+		return $thread->hasParticipant($user->id)
+		    ? Response::allow()
+			: Response::denyAsNotFound();
 	}
-	
+
 	/**
 	 * Determines whether the user dan remove a specific participant from the thread.
-	 * 
+	 *
 	 * Authorization rule:
-	 * - The user MUST be the thread creator. 
+	 * - The user MUST be the thread creator.
 	 * - The participant being removed MUST NOT be the creator themselves.
-	 * 
-	 * Rationale: 
-	 * Managemant of thread membership is centralized with the original creator. 
+	 *
+	 * Rationale:
+	 * Managemant of thread membership is centralized with the original creator.
 	 * This policy prevents the creator from removing themselves, ensuring they maintain responsibility for the thread's structure until it is potentially deleted entirely.
 	 *
 	 * @param  User 	   $user		The user attempting the removal (must be creator).
@@ -81,58 +77,70 @@ final readonly class ThreadPolicy
 	 */
 	public function removeParticipants(User $user, Thread $thread, Participant $participant): Response
 	{
-		if ($thread->creator()->is($user) && $thread->hasParticipant($user->id) && $participant->user()->isNot($thread->creator())) {
-			return Response::allow();
+		if ($thread->creator()->isNot($user)) {
+		    return Response::deny(message: __('Alleen de beheerder van dit gesprek kan deelnemers verwijderen.'));
 		}
-		
-		return Response::deny();
+
+		if ($participant->user()->is($thread->creator())) {
+		    return Response::deny(message: __('De beheerder van het gesprek kan niet worden verwijderd.'));
+		}
+
+		return Response::allow();
 	}
-	
+
 	/**
-	 * Determines whether the user can add new participants to the thread. 
-	 * 
+	 * Determines whether the user can add new participants to the thread.
+	 *
 	 * Authorization rule:
-	 * - The user MUST be the thread creator. 
+	 * - The user MUST be the thread creator.
 	 * - The total number of participants in the thread MUST be less than 5 (i.e, the thread size limit).
 	 *
-	 * Rationale: 
-	 * This centralizes control for expansion with the originator and enforces a strict, system-wide maximum thread size of 5 memebers, 
-	 * preventing large, unmanageable group chats. 
-	 * 
-	 * @param User   $user		The user attempting the action (must be the creator).
-	 * @param Thread $thread	The thread being modified.
+	 * Rationale:
+	 * This centralizes control for expansion with the originator and enforces a strict, system-wide maximum thread size of 5 memebers,
+	 * preventing large, unmanageable group chats.
+	 *
+	 * @param  User   $user		The user attempting the action (must be the creator).
+	 * @param  Thread $thread	The thread being modified.
 	 * @return Response
 	 */
 	public function addParticipants(User $user, Thread $thread): Response
 	{
-		if ($thread->creator()->is($user) && $thread->participants->count() < 5) {
-			return Response::allow();
+		if ($thread->creator()->isNot($user)) {
+		    return Response::deny(message: __('Alleen de beheerder van dit gesprek kan nieuwe deelnemers toevoegen.'));
 		}
-		
-		return Response::deny();
+
+		if ($thread->participants->count() >= 5) {
+		    return Response::deny(message: __('De maximale limit van 5 deelnemers voor dit gesprek is bereikt.'));
+		}
+
+		return Response::allow();
 	}
-	
+
 	/**
-	 * Determines whether the user can leave the thread. 
-	 * 
-	 * Authorization rule: 
-	 * - The user MUST be a current participant in the thread. 
-	 * - The user MUST NOT be the thread creator. 
-	 * 
-	 * Rationale: 
-	 * This allows any regular participant to opt out of a conversation at any time. 
-	 * The creator is permantly anchored to the thread, consistent with their exclusive management responsibilities. 
+	 * Determines whether the user can leave the thread.
 	 *
-	 * @param  User   $user		The user attempting to leave. 
+	 * Authorization rule:
+	 * - The user MUST be a current participant in the thread.
+	 * - The user MUST NOT be the thread creator.
+	 *
+	 * Rationale:
+	 * This allows any regular participant to opt out of a conversation at any time.
+	 * The creator is permantly anchored to the thread, consistent with their exclusive management responsibilities.
+	 *
+	 * @param  User   $user		The user attempting to leave.
 	 * @param  Thread $thread	The thread the user is attempting to leave.
 	 * @return Response
 	 */
 	public function leave(User $user, Thread $thread): Response
 	{
-		if ($thread->hasParticipant($user->id) && $thread->creator()->isNot($user)) {
-			return Response::allow();
+		if (! $thread->hasParticipant($user->id)) {
+		    return Response::denyAsNotFound();
 		}
-		
-		return Response::deny();
+
+		if ($thread->creator()->is($user)) {
+            return Response::deny('Als beheerder kun je dit gesprek niet verlaten.');
+        }
+
+        return Response::allow();
 	}
 }


### PR DESCRIPTION
Deze PR formaliseert de autorisatie regels voor het dupliceren van artikelen binnen de administratie omgeving. De logica is direct gekoppeld aan de bestaande `ArticleStates` enum en volgt het workflow-diagram voor veilig data-beheer. 

### Belangrijkste wijzigingen 

#### 1. Implementatie `duplicate` autorisatie

Er is een strikte controle toegevoegd op basis van de huidige status van een artikel. Duplicatie is alleen toegestaan wanneer een artikel zich bevindt in een status die verdere bewerking of revisie rechtvaardigt. 

- **Toegestane statussen:** `Published`, `Draft`, `Archived`.
- **Beveiliging:** Verwijderde artikelen (`trashed`) zijn expliciet uitgesloten van duplicatie. 

#### 2. Dynamische feedback 

In plaats van statische tekst, gebruikt de policy nu vertaalbare berichten met placeholders. Dit zorgt ervoor dat de gebruiker in de UI exact ziet waarom een actie geweigerd wordt (bijv. "Artikelen in de status Eindredactie kunnen niet worden gedupliceerd")/ 

### Rationele overwegingen voor duplicatie-instellingen 

1. **Backups:** Redacteurs kunnen experimenteren met artikelen door in `Draft` kopieen te maken. 
2. **Revisies:** Live artikelen (`published`) kunnen gedupliceerd worden naar een nieuwe kladversie voor updates zonder de live-versie te verstoren. 
3. **Hergebruik**: Oude data uit het archiefbestand kunnen dienen als basis voor nieuwe lemma's.

### Varia 

Ps. @Taalmiet als hier nog vragen over zijn of je denkt nog aan zaken mag je het gerust laten weten. 
