### PR TITLE
feat(user-examples): polymorfe exampleable-relatie i.p.v. directe Article-koppeling

### DIFF
--- a/app/Filament/Clusters/Articles/Resources/ExampleSentences/Actions/MigrateExamplesAction.php
+++ b/app/Filament/Clusters/Articles/Resources/ExampleSentences/Actions/MigrateExamplesAction.php
@@ -38,15 +38,11 @@ final class MigrateExamplesAction extends Action
             $article = $livewire->getOwnerRecord();
 
             DB::transaction(function () use ($data, $article) {
-                // 1. Create the new examples
-                collect($data['userExamples'])->each(fn (array $example) => UserExample::query()->create(array_merge($example, [
-                    'article_id' => $article->id,
+                collect($data['userExamples'])->each(fn (array $example) => $article->userExamples()->create(array_merge($example, [
                     'user_id' => auth()->id(),
                     'status' => Approved::class,
-                ]))
-                );
+                ])));
 
-                // 2. Mark the article as migrated so the button disappears
                 $config = $article->migration_configuration ?? [];
                 $config['examples'] = true;
 

--- a/app/Filament/Clusters/Articles/Resources/ExampleSentences/ExampleSentenceResource.php
+++ b/app/Filament/Clusters/Articles/Resources/ExampleSentences/ExampleSentenceResource.php
@@ -9,6 +9,7 @@ use App\Filament\Clusters\Articles\Resources\ExampleSentences\Pages\ListExampleS
 use App\Filament\Clusters\Articles\Resources\ExampleSentences\Schema\ExampleSentenceForm;
 use App\Filament\Clusters\Articles\Resources\ExampleSentences\Tables\ExampleSentencesTable;
 use App\Filament\Support\Concerns\HasActiveIcon;
+use App\Models\Article;
 use App\Models\UserExample;
 use BackedEnum;
 use Filament\Resources\Resource;
@@ -49,6 +50,6 @@ final class ExampleSentenceResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return (string) self::$model::count();
+        return (string) self::$model::whereMorphRelation('exampleable', Article::class, 'id', '!=', null)->count();
     }
 }

--- a/app/Filament/Clusters/Articles/Resources/ExampleSentences/Tables/ExampleSentencesTable.php
+++ b/app/Filament/Clusters/Articles/Resources/ExampleSentences/Tables/ExampleSentencesTable.php
@@ -7,6 +7,7 @@ namespace App\Filament\Clusters\Articles\Resources\ExampleSentences\Tables;
 use A909M\FilamentStateFusion\Actions\StateFusionAction;
 use A909M\FilamentStateFusion\Actions\StateFusionBulkAction;
 use App\Filament\Resources\Articles\ArticleResource;
+use App\Models\Article;
 use App\Models\UserExample;
 use App\Policies\UserExamplePolicy;
 use App\States\ExampleSentence\Rejected;
@@ -29,10 +30,7 @@ final readonly class ExampleSentencesTable
     public static function configure(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->with([
-                'article:id,word',
-                'author:id,name'
-            ]))
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['exampleable:id,word', 'author:id,name'])->whereMorphRelation('exampleable', Article::class, 'id', '!=', null))
             ->heading(heading: 'Overzicht van Voorbeeldzinnen')
             ->description(description: 'Een overzicht van alle Voorbeeldzinnen die zijn aangedragen door gebruikers van het Vlaams Woordenboek. In de onderstaande tabel vind je een overzicht van alle voorbeelden die nog beoordeeld moeten worden.')
             ->headerActions(actions: self::registerTableHeaderActions())
@@ -76,13 +74,13 @@ final readonly class ExampleSentencesTable
     private static function registerTableColumns(): array
     {
         return [
-            TextColumn::make('article.word')
+            TextColumn::make('exampleable.word')
                 ->label('artikel')
                 ->icon(Heroicon::OutlinedDocumentText)
                 ->iconColor('primary')
                 ->weight(FontWeight::Bold)
                 ->color('primary')
-                ->url(fn (UserExample $userExample): string => ArticleResource::getUrl('view', ['record' => $userExample->article]))
+                ->url(fn (UserExample $userExample): string => ArticleResource::getUrl('view', ['record' => $userExample->exampleable]))
                 ->searchable()
                 ->sortable(),
 

--- a/app/Livewire/SubmitUserExample.php
+++ b/app/Livewire/SubmitUserExample.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Livewire;
 
+use App\Models\Article;
 use Livewire\Component;
-use App\Models\UserExample;
 use Illuminate\Contracts\Support\Renderable;
 use Livewire\Attributes\Validate;
 
-class SubmitUserExample extends Component
+final class SubmitUserExample extends Component
 {
+    public Article $article;
+
     public int|string|null $articleId;
 
     public ?string $cssClasses = null;
@@ -26,7 +30,7 @@ class SubmitUserExample extends Component
 
     public function mount($articleId = null, ?string $cssClasses = null): void
     {
-        $this->articleId = $articleId;
+        $this->article = Article::findOrFail($articleId);
         $this->cssClasses = $cssClasses;
     }
 
@@ -43,13 +47,11 @@ class SubmitUserExample extends Component
     {
         $this->validate();
 
-        UserExample::create([
-            'article_id' => $this->articleId,
-            'user_id' => auth()->id(),
+        $this->article->userExamples()->create([
+            'user_id'          => auth()->id(),
             'contributor_name' => auth()->check() ? auth()->user()->name : ($this->contributorName ?: 'Anoniem'),
-            'example' => $this->example,
-            'source' => $this->source,
-            'cssClasses' => $this->cssClasses,
+            'example'          => $this->example,
+            'source'           => $this->source,
         ]);
 
         $this->submitted = true;

--- a/app/Livewire/UserExamplesList.php
+++ b/app/Livewire/UserExamplesList.php
@@ -42,7 +42,7 @@ class UserExamplesList extends Component
         $direction = $this->sortBy === 'created_at_asc' ? 'asc' : 'desc';
 
         return UserExample::query()
-            ->where('article_id', $this->articleId)
+            ->whereMorphRelation('exampleable', Article::class, 'id', '=', $this->article->getKey())
             ->whereState('status', Approved::class)
             ->with('author')
             ->orderBy('created_at', $direction)

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -17,9 +17,11 @@ use App\Models\Relations\Articles\HasCorrectionSupport;
 use App\Models\Relations\BelongsToAuthor;
 use App\Models\Relations\BelongsToEditor;
 use App\Models\Relations\BelongsToManyRegions;
+use App\Observers\ArticleObserver;
 use Carbon\Carbon;
 use Database\Factories\ArticleFactory;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -29,6 +31,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Kirschbaum\Commentions\Contracts\Commentable;
 use Kirschbaum\Commentions\HasComments;
@@ -79,6 +82,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  */
 #[Guarded(columns: 'id')]
 #[UseEloquentBuilder(builderClass: ArticleBuilder::class)]
+#[ObservedBy(ArticleObserver::class)]
 final class Article extends Model implements AuditableContract, Commentable
 {
     /**
@@ -250,9 +254,9 @@ final class Article extends Model implements AuditableContract, Commentable
      *
      * @return HasMany<UserExample, covariant $this>
      */
-    public function userExamples(): HasMany
+    public function userExamples(): MorphMany
     {
-        return $this->hasMany(UserExample::class);
+        return  $this->morphMany(UserExample::class, 'exampleable');
     }
 
     /**

--- a/app/Models/UserExample.php
+++ b/app/Models/UserExample.php
@@ -7,6 +7,9 @@ namespace App\Models;
 use App\States\ExampleSentence\SentenceState;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Spatie\ModelStates\HasStates;
 
@@ -31,6 +34,7 @@ use Spatie\ModelStates\HasStates;
 final class UserExample extends Model
 {
     use HasStates;
+    use SoftDeletes;
 
     /**
      * Mass assignment configuration
@@ -42,17 +46,9 @@ final class UserExample extends Model
      */
     protected $guarded = ['id'];
 
-    /**
-     * Parent article relationship
-     *
-     * Every example sentence is contextually tied to a specific dictionary article.
-     * This relationship is critival for grouping examples within the frontend dictionary views.
-     *
-     * @return BelongsTo<Article, covariant $this>
-     */
-    public function article(): BelongsTo
+    public function exampleable(): MorphTo
     {
-        return $this->belongsTo(Article::class);
+        return $this->morphTo();
     }
 
     /**

--- a/app/Observers/ArticleObserver.php
+++ b/app/Observers/ArticleObserver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Article;
+
+final readonly class ArticleObserver
+{
+    public function deleting(Article $article): void
+    {
+        $article->userExamples()->delete();
+    }
+}

--- a/app/Observers/ArticleObserver.php
+++ b/app/Observers/ArticleObserver.php
@@ -10,6 +10,15 @@ final readonly class ArticleObserver
 {
     public function deleting(Article $article): void
     {
-        $article->userExamples()->delete();
+        if ($article->isForceDeleting()) {
+            $article->userExamples()->forceDelete();
+        } else {
+            $article->userExamples()->delete();
+        }
+    }
+
+    public function restoring(Article $article): void
+    {
+        $article->userExamples()->restore();
     }
 }

--- a/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
+++ b/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
@@ -12,20 +12,16 @@ return new class extends Migration
     {
         Schema::table('user_examples', function (Blueprint $table): void {
             $table->dropForeign(['article_id']);
-        });
-
-        Schema::table('user_examples', function (Blueprint $table): void {
             $table->string('exampleable_type')->nullable()->after('status');
             $table->renameColumn('article_id', 'exampleable_id');
+            $table->index(['exampleable_type', 'exampleable_id']);
             $table->softDeletes();
         });
 
-        DB::table('user_examples')->update([
-            'exampleable_type' => Article::class,
-        ]);
+        DB::table('user_examples')->update(['exampleable_type' => Article::class]);
 
         Schema::table('user_examples', function (Blueprint $table): void {
-            $table->index(['exampleable_type', 'exampleable_id']);
+            $table->string('exampleable_type')->nullable(false)->change();
         });
     }
 

--- a/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
+++ b/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Article;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_examples', function (Blueprint $table): void {
+            $table->after('status', function() use($table): void {
+                $table->string('exampleable_type')->nullable();
+            });
+
+            $table->renameColumn('article_id', 'exampleable_id');
+            $table->softDeletes();
+        });
+
+        DB::table('user_examples')->update([
+            'exampleable_type' => Article::class,
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_examples', function (Blueprint $table): void {
+            $table->dropColumn('exampleable_type');
+            $table->renameColumn('exampleable_id', 'article_id');
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
+++ b/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
@@ -14,11 +14,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('user_examples', function (Blueprint $table): void {
+            $table->dropForeign(['article_id']);
+
             $table->after('status', function() use($table): void {
                 $table->string('exampleable_type')->nullable();
             });
 
             $table->renameColumn('article_id', 'exampleable_id');
+            $table->index(['exampleable_type', 'exampleable_id']);
             $table->softDeletes();
         });
 

--- a/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
+++ b/database/migrations/2026_06_19_005554_set_user_examples_relation_to_morph_relation.php
@@ -8,34 +8,55 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::table('user_examples', function (Blueprint $table): void {
             $table->dropForeign(['article_id']);
+        });
 
-            $table->after('status', function() use($table): void {
-                $table->string('exampleable_type')->nullable();
-            });
-
+        Schema::table('user_examples', function (Blueprint $table): void {
+            $table->string('exampleable_type')->nullable()->after('status');
             $table->renameColumn('article_id', 'exampleable_id');
-            $table->index(['exampleable_type', 'exampleable_id']);
             $table->softDeletes();
         });
 
         DB::table('user_examples')->update([
             'exampleable_type' => Article::class,
         ]);
+
+        Schema::table('user_examples', function (Blueprint $table): void {
+            $table->index(['exampleable_type', 'exampleable_id']);
+        });
     }
 
     public function down(): void
     {
         Schema::table('user_examples', function (Blueprint $table): void {
-            $table->dropColumn('exampleable_type');
-            $table->renameColumn('exampleable_id', 'article_id');
-            $table->dropSoftDeletes();
+            if (Schema::hasIndex('user_examples', 'user_examples_exampleable_type_exampleable_id_index')) {
+                $table->dropIndex(['exampleable_type', 'exampleable_id']);
+            }
+        });
+
+        Schema::table('user_examples', function (Blueprint $table): void {
+            if (Schema::hasColumn('user_examples', 'exampleable_type')) {
+                $table->dropColumn('exampleable_type');
+            }
+        });
+
+        if (Schema::hasColumn('user_examples', 'exampleable_id') && ! Schema::hasColumn('user_examples', 'article_id')) {
+            Schema::table('user_examples', function (Blueprint $table): void {
+                $table->renameColumn('exampleable_id', 'article_id');
+            });
+        }
+
+        Schema::table('user_examples', function (Blueprint $table): void {
+            if (Schema::hasColumn('user_examples', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+
+        Schema::table('user_examples', function (Blueprint $table): void {
+            $table->foreign('article_id')->references('id')->on('articles');
         });
     }
 };


### PR DESCRIPTION
Ik migreer de relatie tussen `UserExample` en `Article` naar een polymorfe `exampleable` relatie. Dit is de voorbereiding om in de toekomst andere entiteiten aan voorbeelden te kunnen koppelen. 

**Architecturale keuze:** Er wordt bewust geen morph map gebruikt om de codebase minder complex te houden. Dit betekent dat de volledige class-naam in de database staat, bij een eventuele rename van `Article` moet de database handmatig worden bijgewerkt. 

## Belangrijkste wijzigingen 

- **Schema:** `article_id` is vervangen door `exampleable_id` + `exampleable_type` (met composite index). 
- **Soft deletes:** `UserExamples` ondersteunt ny `soft_deletes`. 
- **Cascading:** De nieuwe `ArticleObserver` zorgt ervoor dat soft-delete/restore acties op een artikel nu automatisch doorwerken naar de voorbeeldzinnen. 
- **Integraties:** Filament/Livewire resources en acties zijn bijgewerkt naar de nieuwe relatie: `UserExampleList` gebruikt nu `whereMorphRelation`. 

## Voor de reviewer (self-review)

- **Cascade gedrag:** De `ArticleObserver` woert nu een hard-en-soft cascade uit. Dit lijkt me de meest logische keuze, indien we hier toch een explicietere controle opwillen kunnen we eventueel toch nog een morph map implementeren. 

- **Breaking change:** De migratie is defensief geschreven, maar let op bij het migreren op bestaande data. Een back-up vooraf is aanbevolen. 