### PR TITLE
fix: maak suggesties dupliceerbaar

### DIFF
--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -152,7 +152,7 @@ final class ArticlePolicy
      */
     public function duplicate(User $user, Article $article): Response
     {
-        $cloneableStates = [ArticleStates::Published, ArticleStates::Draft, ArticleStates::Archived];
+        $cloneableStates = [ArticleStates::Published, ArticleStates::New, ArticleStates::Draft, ArticleStates::Archived];
 
         if ($article->trashed()) {
             return Response::deny(message: __('Je kan geen verwijderd artikel dupliceren.'));


### PR DESCRIPTION
Momenteel is het niet mogelijk om artikelen met de status `New` (suggesties/nieuwe artikelen) te dupliceren. Deze optie was voorheen beperkt tot `Published`, `Draft`, `Archived`.

Deze Pull Request voegt `ArticleStates::New` toe aan de lijst met `cloneableStates` in de `ArticlePolicy`, zodat gebruikers ook voorgestelde or net aangemaakte artikelen direct kunnen kopieren. 

## Wijzigingen 

- `app\Policies\ArticlePolicy.php`: `ArticleStates::New` toegevoegd aan de toegestane statussen binnen de `duplicate` permissie-check. 

## Impact & Risico's 

- **Risico:** Zeer laag. Het publiceren van een nieuw/gesuggereerd artikel volgt exact dezelfde logica als een concept (`Draft`).

- **Impact:** Verbetert de workflow van redacteurs die op basis van een binnengekomen suggestie snel een variant willen.