### PR TITLE
Fix #602: Optimalisatie moderatie workflow en geruisloze opslag voor artikelmeldingen

### DIFF
--- a/app/Filament/Clusters/Articles/Resources/ArticleReports/Actions/CloseArticleReportAction.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleReports/Actions/CloseArticleReportAction.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Filament\Clusters\Articles\Resources\ArticleReports\Actions;
 
+use App\Filament\Clusters\Articles\Resources\ArticleReports\Pages\EditArticleReport;
 use App\Models\ArticleReport;
 use App\States\Reporting\Status;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Schemas\Components\Callout;
+use Filament\Support\Enums\IconSize;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Schmeits\FilamentCharacterCounter\Forms\Components\Textarea;
 
 /**
@@ -47,15 +52,10 @@ final class CloseArticleReportAction extends Action
         $this->requiresConfirmation();
         $this->modalIconColor(Status::Closed->getColor());
         $this->modalIcon(Status::Closed->getIcon());
+        $this->modalWidth(Width::TwoExtraLarge);
         $this->modalDescription('U staat op het punt om een melding te sluiten. Geef hier nog even op waarom u de melding afsluit: is die afgehandeld, niet relevant, of is er iets anders aan de hand?');
 
-        $this->schema([
-            Textarea::make('result')
-                ->label('Eindbesluit')
-                ->required()
-                ->placeholder('Beschrijf kort wat je hebt gedaan om de melding te verhelpen.')
-                ->rows(4),
-        ]);
+        $this->schema(schema: $this->getActionFormSchema());
 
         $this->successNotificationTitle('Het ticket is succesvol afgesloten');
         $this->failureNotificationTitle('Helaas konden we het ticket niet afsluiten wegens een technische fout');
@@ -63,6 +63,12 @@ final class CloseArticleReportAction extends Action
         $this->action(function (array $data): void {
             /** @var ArticleReport $record */
             $record = $this->getRecord();
+
+            $livewire = $this->getLivewire();
+
+            if ($livewire instanceof EditArticleReport) {
+                $livewire->saveQuietly();
+            }
 
             if ($this->process(fn (): bool => $record->status()->transitionToClosed($data['result']))) {
                 $this->success();
@@ -72,6 +78,27 @@ final class CloseArticleReportAction extends Action
 
             $this->failure();
         });
+    }
+
+    /**
+     * @return array<int, Callout|Textarea>
+     */
+    protected function getActionFormSchema(): array
+    {
+        return [
+            Callout::make('Kan de melding niet afsluiten')
+                ->description('De ingevulde velden in het formulier zijn niet conform met de validatieregels, sluit deze pop-up en verhelp de problemen.')
+                ->iconSize(IconSize::Medium)
+                ->icon(Heroicon::OutlinedExclamationTriangle)
+                ->hidden(fn (): bool => $this->getLivewire()->getErrorBag()->isEmpty())
+                ->danger(),
+
+            Textarea::make('result')
+                ->label('Eindbesluit')
+                ->required()
+                ->placeholder('Beschrijf kort wat je hebt gedaan om de melding te verhelpen.')
+                ->rows(4),
+        ];
     }
 
     /**

--- a/app/Filament/Clusters/Articles/Resources/ArticleReports/Pages/EditArticleReport.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleReports/Pages/EditArticleReport.php
@@ -9,8 +9,11 @@ use App\Filament\Clusters\Articles\Resources\ArticleReports\ArticleReportResourc
 use App\Filament\Resources\Users\UserResource;
 use App\Models\ArticleReport;
 use App\Models\User;
+use App\States\Reporting\Status;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Icons\Heroicon;
 
@@ -25,19 +28,81 @@ use Filament\Support\Icons\Heroicon;
  */
 final class EditArticleReport extends EditRecord
 {
+    /**
+     * Links this page to the main article report resource.
+     *
+     * @var string
+     */
     protected static string $resource = ArticleReportResource::class;
 
+    /**
+     * Controls whether the success notification is shown to the user after saving.
+     * When true, the visual feedback popup is completely suppressed.
+     *
+     * @var bool
+     */
+    public bool $suppressSavedNotification = false;
+
+    /**
+     * Sets the breadcrumb label for this page to reflect its active moderation state.
+     *
+     * @return string
+     */
     public function getBreadcrumb(): string
     {
         return 'Behandelen';
     }
 
+    /**
+     * Sets the main page heading to indicate that the report is currently being processed.
+     *
+     * @return string
+     */
     public function getTitle(): string
     {
         return 'Melding behandelen';
     }
 
     /**
+     * Determines which notification to send to the UI after a successful save.
+     * If the notification supression flag is active, this returns null to bypass the UI popup.
+     *
+     * @return Notification|null
+     */
+    protected function getSavedNotification(): ?Notification
+    {
+        if ($this->suppressSavedNotification) {
+            return null;
+        }
+
+        return parent::getSavedNotification();
+    }
+
+    /**
+     * Saves the form changes silently to the database.
+     *
+     * This temporarily supresses and then restores the success notification to prevent
+     * cluttering the user interface during automated state updates.
+     *
+     * @return void
+     */
+    public function saveQuietly(): void
+    {
+        $this->suppressSavedNotification = true;
+        $this->save();
+        $this->suppressSavedNotification = false;
+    }
+
+    /**
+     * Configures the header actions for the moderation workflow.
+     *
+     * Offers quick-access buttons to:
+     *
+     * - View the reporter's user profile (if authorized and reporter still exists).
+     * - Close/Resolve the report.
+     * - Safely cancel the operation with a confirmation model that warns of unsaved changes.
+     * - Delete the report entirely.
+     *
      * @return array<Action> An array of configured header actions.
      */
     protected function getHeaderActions(): array
@@ -51,25 +116,39 @@ final class EditArticleReport extends EditRecord
                 ->color('gray')
                 ->url(fn (ArticleReport $articleReport): string => UserResource::getUrl('view', ['record' => $articleReport->author])),
 
-            CloseArticleReportAction::make(),
+            ActionGroup::make(actions: [
+                CloseArticleReportAction::make(),
+
+                Action::make('cancel')
+                    ->hidden(fn (ArticleReport $articleReport): bool => $articleReport->state->is(Status::Closed))
+                    ->icon(Heroicon::OutlinedXCircle)
+                    ->label('Annuleren')
+                    ->color('gray')
+                    ->requiresConfirmation()
+                    ->modalCloseButton(false)
+                    ->modalIcon(Heroicon::OutlinedXCircle)
+                    ->modalIconColor('danger')
+                    ->modalHeading('Behandeling annuleren')
+                    ->modalDescription('U staat op het punt om de behandeling van een melding te annuleren. Daardoor zullen de wijzigingen in het formulier niet worden opgeslagen. Ben je zeker dat je dit wilt doen?')
+                    ->action(fn () => $this->redirect($this->previousUrl ?? static::getResource()::getUrl('index')))
+                    ->modalSubmitActionLabel('Ja, ik ben zeker')
+                    ->modalSubmitAction(fn (\Filament\Actions\Action $action) => $action->color('danger')),
+            ])->buttonGroup(),
+
             DeleteAction::make()->icon('heroicon-o-trash'),
         ];
     }
 
+    /**
+     * Disables the defualt footer actions.
+     *
+     * By returning an empty array, the standard "Save" and "Cancel" buttons at the bottom of the form are hidden,
+     * funneling all moderation flow decisions through the header actions.
+     *
+     * @return array
+     */
     protected function getFormActions(): array
     {
-        return [
-            Action::make('save')
-                ->icon(Heroicon::OutlinedCheck)
-                ->label('Opslaan')
-                ->requiresConfirmation()
-                ->modalHeading('Wijzigingen opslaan')
-                ->modalDescription('Ben je zeker dat je de wijzigingen wilt opslaan?')
-                ->modalSubmitActionLabel('Ja, opslaan')
-                ->action(fn () => $this->save()),
-
-            $this->getCancelFormAction()
-                ->icon(icon: Heroicon::OutlinedXCircle),
-        ];
+        return [];
     }
 }


### PR DESCRIPTION
Deze pull request verbetert de gebruikerservaring en de technische betrouwbaarheid bij het behandelen van artikelmeldingen (`ArticleReport`). 

We verplaatsen de primaire formulier acties volledig naar de header van de pagina en groeperen deze logisch. 
Daarnaast slaan we nu bij het sluiten van een melding eerst geruisloos de wijzigingen in het formulier op, mits er geen validatie fouten zijn. Als er wel validatiefouten op de pagina staan, tonen we direct een duidelijke waarschuwing in te model van de sluit actie. 

## Belangrijkste wijzigingen 

### 1. Pagina: `EditArticleReport.php`

- **Geen dubbele knoppen meer:** De standaard filament-actieknoppen onderaan het formulier (`getFormActions`) zijn volledig uitgeschakeld. Redacteurs worden nu consistent naar de acties in de header geleid. 

- **Betere groepering:** De sluit- en annuleeracties zijn samengevoegd in een strakke `ActionGroup::buttonGroup()`. 

- **Geruisloos opslaan (`saveQuietly`)**: Logica toegevoegd om het formulier in de achtergrond op te slaan zonder dat de standaard "opgeslagen" pop-up melding de UI overspoelt. 

- **Code quality:** Alle properties en methodes zijn voorzien van up-to-date, open-source waardige docblocks. 

### 2. Actie: `CloseArticleReportAction.php`

- **Automatisch opslaan voor sluiten:** Voordat de transitie naar `Status::Closed` wordt ingezet, wordt de actieve Livewire-pagina geruisloos opgeslagen. 

- **Validatie feedback in de modal:** de modal breedte is vergroot naar `2XL` om ruimte te bieden aan de nieuwe `Callout` component. Deze waarschuwt de redacteur direct binnen de pop-up als er nog onopgeloste validatiefouten in het hoordformulier staan. 

## Impact op User Experience (UX)

**Voorheen:** redeacteurs moesten handmatig onderaan de pagina op "Opslaan" klikken voordat ze de melding konden sluiten, wat vaak vergeten werd of voor verwarring zorgde. 

**Nu:** een redacteur klikt op `Melding sluiten` in de header. Het systeem slaat eventuele wijzigingen geruisloos op in de achtergrond en sluit de melding direct af. Zijn er fouten op de pagina? Dan krijgt de behandelende redacteurs hier direct een waarschuwing over binnen in de geopende modal.