### PR TITLE
feat (#514): Afgewezen suggestie state en implementatie van moderatie workflow

### DIFF
--- a/app/Contracts/States/ArticleStateContract.php
+++ b/app/Contracts/States/ArticleStateContract.php
@@ -64,4 +64,6 @@ interface ArticleStateContract
     public function transitionToExternalData(): bool;
 
     public function transitionToRejectedPublication(array $feedback): bool;
+
+    public function transitionToRejectedSuggestion(array $feedback): bool;
 }

--- a/app/Enums/ArticleStates.php
+++ b/app/Enums/ArticleStates.php
@@ -41,6 +41,7 @@ enum ArticleStates: int implements HasLabel, HasIcon, HasColor, HasDescription
     case Archived = 4;              // The article has been archived, meaning it's no longer actively displayed but is kept for historical or reference purposes.
     case ExternalData = 5;          // The article contains information imported from an external source or database integration.
     case RejectedPublication = 6;   // The article was submitted for review but was denied and is not scheduled for publication.
+    case RejectedSuggestion = 7;
 
     /**
      * Returns the human-readable Dutch label for each state.
@@ -58,6 +59,7 @@ enum ArticleStates: int implements HasLabel, HasIcon, HasColor, HasDescription
             self::Archived => 'Gearchiveerd',
             self::ExternalData => 'Externe data',
             self::RejectedPublication => 'Afgewezen publicatie',
+            self::RejectedSuggestion => 'Afgewezen suggestie',
         };
     }
 
@@ -69,7 +71,8 @@ enum ArticleStates: int implements HasLabel, HasIcon, HasColor, HasDescription
             self::Approval => __('Artikelen die zijn ingediend ter controle alvorens de publicatie plaatsvind'),
             self::Published => __('Artikelen die reeds zijn gepubliceerd in het Vlaams Woordenboek'),
             self::Archived => __('Artikelen die niet meer relevant zijn en daarom gearchiveerd zijn'),
-            self::RejectedPublication => __('Artikelen die zijn afgewezen wegens het niet voldoen aan de redactionele richtlijnen.')
+            self::RejectedPublication => __('Artikelen die zijn afgewezen wegens het niet voldoen aan de redactionele richtlijnen.'),
+            self::RejectedSuggestion => __('Suggesties voor artikelen die zijn afgewezen door het redactie team.')
         };
     }
 
@@ -86,7 +89,7 @@ enum ArticleStates: int implements HasLabel, HasIcon, HasColor, HasDescription
             self::Draft => 'warning',
             self::Approval => 'primary',
             self::Published => 'success',
-            self::Archived , self::RejectedPublication => 'danger',
+            self::Archived , self::RejectedPublication, self::RejectedSuggestion => 'danger',
         };
     }
 

--- a/app/Filament/Clusters/Articles/Resources/ArticleResource/Actions/RejectSuggestionAction.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleResource/Actions/RejectSuggestionAction.php
@@ -48,6 +48,8 @@ final class RejectSuggestionAction extends Action
             ];
         });
 
+        $this->successNotificationMessage('De suggestie is met success afgewezen.');
+
         $this->schema(schema: $this->formSchema());
 
         $this->action(function (array $data): void {

--- a/app/Filament/Clusters/Articles/Resources/ArticleResource/Actions/RejectSuggestionAction.php
+++ b/app/Filament/Clusters/Articles/Resources/ArticleResource/Actions/RejectSuggestionAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Clusters\Articles\Resources\ArticleResource\Actions;
+
+use App\Models\Article;
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\Support\Htmlable;
+use Override;
+use Schmeits\FilamentCharacterCounter\Forms\Components\Textarea;
+
+final class RejectSuggestionAction extends Action
+{
+    use CanCustomizeProcess;
+
+    protected Heroicon $actionIcon = Heroicon::OutlinedArchiveBoxXMark;
+
+    public static function getDefaultName(): string
+    {
+        return 'reject-suggestion';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Suggestie afwijzen');
+        $this->color('gray');
+        $this->icon($this->actionIcon);
+
+        $this->authorize('reject-suggestion', $this->record);
+
+        $this->modal();
+        $this->modalIcon($this->actionIcon);
+        $this->modalIconColor('danger');
+        $this->modalCloseButton(false);
+        $this->modalWidth(Width::Large);
+        $this->requiresConfirmation();
+        $this->modalFooterActions(function (Action $action): array {
+            return [
+                $this->getModalCancelAction(),
+                $this->getModalSubmitAction()
+                    ->color('danger')
+            ];
+        });
+
+        $this->schema(schema: $this->formSchema());
+
+        $this->action(function (array $data): void {
+            if ($this->process(fn (Article $article): bool => $article->articleStatus()->transitionToRejectedSuggestion($data))) {
+                $this->success();
+                return;
+            }
+
+            $this->failure();
+        });
+    }
+
+    protected function formSchema(): array
+    {
+        return [
+            Textarea::make('rejection_reason')
+                ->required()
+                ->hiddenLabel()
+                ->rows(5)
+                ->placeholder('Beschrijf kort waarom de suggestie word afgewezen in het Vlaams Woordenboek.')
+                ->showCharacterCounter(false),
+        ];
+    }
+
+    public function getModalDescription(): string
+    {
+        return __('Wijs deze suggestie af en geef korte feedback zodat de gebruiker weet waarom deze niet wordt gepubliceerd.');
+    }
+}

--- a/app/Filament/Resources/Articles/Pages/ViewWord.php
+++ b/app/Filament/Resources/Articles/Pages/ViewWord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\Articles\Pages;
 
+use App\Filament\Clusters\Articles\Resources\ArticleResource\Actions\RejectSuggestionAction;
 use App\Filament\Resources\Articles\Actions\DuplicationArticleAction;
 use App\Filament\Resources\Articles\Actions\PreviewArticleAction;
 use App\Filament\Resources\Articles\Actions\RevokePublication;
@@ -149,6 +150,7 @@ final class ViewWord extends ViewRecord
     {
         return ActionGroup::make([
             FilamentActions\EditAction::make()->icon('heroicon-o-pencil-square')->color('gray'),
+            RejectSuggestionAction::make(),
             DuplicationArticleAction::make(),
             ArticleStateActions\ArchiveArticle::make(),
             ArticleStateActions\PublishArticleAction::make(),

--- a/app/Filament/Resources/Articles/Schema/WordInfolist.php
+++ b/app/Filament/Resources/Articles/Schema/WordInfolist.php
@@ -80,7 +80,7 @@ final readonly class WordInfolist
             ->columnSpanFull()
             ->visible(fn (Article $article): bool => $article->isRejectedSuggestion())
             ->icon(Heroicon::OutlinedArchiveBoxXMark, IconAnimation::Pulse)
-            ->title(fn (Article $article): string => __(':user heeft deze suggestie :date afgewezen', ['user' => $article->rejectedBy->name, 'date' => $article->updated_at->diffForHumans()]))
+            ->title(fn (Article $article): string => __(':user heeft deze suggestie :date afgewezen', ['user' => $article->rejectedBy->name ?? 'Onbekende/verwijderde gebruiker', 'date' => $article->updated_at->diffForHumans()]))
             ->description(fn (Article $article): string => $article->rejection_reason ?? 'Geen feedback opgegegevn voor de gebruiker.')
             ->border()
             ->color('danger');

--- a/app/Filament/Resources/Articles/Schema/WordInfolist.php
+++ b/app/Filament/Resources/Articles/Schema/WordInfolist.php
@@ -59,39 +59,9 @@ final readonly class WordInfolist
         return $schema
             ->columns(12)
             ->components([
-                SimpleAlert::make('test')
-                    ->icon(Heroicon::OutlinedArchiveBox, IconAnimation::Pulse)
-                    ->title(fn (Article $article): HtmlString => self::archiveInformationAlert($article)['title'])
-                    ->description(fn (Article $article): HtmlString => self::archiveInformationAlert($article)['description'])
-                    ->visible(fn (Article $article): bool => $article->isArchived() && ! $article->trashed())
-                    ->actions([
-                        Action::make('Bekijk verwijsartikel')
-                            ->visible(fn (Article $article) => $article->redirect_article_id)
-                            ->color('gray')
-                            ->outlined()
-                            ->icon(Heroicon::OutlinedEye)
-                            ->url(fn (Article $article): string => ArticleResource::getUrl('view', ['record' => $article->redirect_article_id])),
-
-                        UnarchiveAction::make()->label('Ongedaan maken')->color('danger')->outlined()
-                    ])
-                    ->border()
-                    ->color('danger')
-                    ->columnSpanFull(),
-
-                SimpleAlert::make('delete-alert')
-                    ->title('Verwijderd artikel')
-                    ->description(fn (Article $article): string => __('je raadpleegd momenteel een door :user verwijderd artikel. Dat gemarkeerd is wegens :reason', [
-                        'user' => $article->deletedBy->name ?? config('app.name', 'Laravel'),
-                        'reason' => $article->deletion_reason ?? 'onbekend'
-                    ]))
-                    ->columnSpanFull()
-                    ->icon(Heroicon::OutlinedTrash, IconAnimation::Pulse)
-                    ->visible(fn (Article $article): bool => $article->trashed())
-                    ->color('danger')
-                    ->actions([
-                        RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
-                        ForceDeleteAction::make()->icon('heroicon-o-trash'),
-                    ]),
+                self::archivedAlert(),
+                self::deleteAlert(),
+                self::rejectedSuggestionAlert(),
 
                 Tabs::make('lemma-information')
                     ->columnSpan(12)
@@ -102,6 +72,58 @@ final readonly class WordInfolist
                         self::publicationInformationTab(),
                     ]),
             ]);
+    }
+
+    private static function rejectedSuggestionAlert(): SimpleAlert
+    {
+        return SimpleAlert::make('rejected-suggestion-alert')
+            ->columnSpanFull()
+            ->visible(fn (Article $article): bool => $article->isRejectedSuggestion())
+            ->icon(Heroicon::OutlinedArchiveBoxXMark, IconAnimation::Pulse)
+            ->title(fn (Article $article): string => __(':user heeft deze suggestie :date afgewezen', ['user' => $article->rejectedBy->name, 'date' => $article->updated_at->diffForHumans()]))
+            ->description(fn (Article $article): string => $article->rejection_reason ?? 'Geen feedback opgegegevn voor de gebruiker.')
+            ->border()
+            ->color('danger');
+    }
+
+    private static function archivedAlert(): SimpleAlert
+    {
+        return SimpleAlert::make('test')
+            ->icon(Heroicon::OutlinedArchiveBox, IconAnimation::Pulse)
+            ->title(fn (Article $article): HtmlString => self::archiveInformationAlert($article)['title'])
+            ->description(fn (Article $article): HtmlString => self::archiveInformationAlert($article)['description'])
+            ->visible(fn (Article $article): bool => $article->isArchived() && ! $article->trashed())
+            ->actions([
+                Action::make('Bekijk verwijsartikel')
+                    ->visible(fn (Article $article) => $article->redirect_article_id)
+                    ->color('gray')
+                    ->outlined()
+                    ->icon(Heroicon::OutlinedEye)
+                    ->url(fn (Article $article): string => ArticleResource::getUrl('view', ['record' => $article->redirect_article_id])),
+
+                UnarchiveAction::make()->label('Ongedaan maken')->color('danger')->outlined()
+            ])
+            ->border()
+            ->color('danger')
+            ->columnSpanFull();
+    }
+
+    private static function deleteAlert(): SimpleAlert
+    {
+        return SimpleAlert::make('delete-alert')
+            ->title('Verwijderd artikel')
+            ->description(fn (Article $article): string => __('je raadpleegd momenteel een door :user verwijderd artikel. Dat gemarkeerd is wegens :reason', [
+                'user' => $article->deletedBy->name ?? config('app.name', 'Laravel'),
+                'reason' => $article->deletion_reason ?? 'onbekend'
+            ]))
+                ->columnSpanFull()
+                ->icon(Heroicon::OutlinedTrash, IconAnimation::Pulse)
+                ->visible(fn (Article $article): bool => $article->trashed())
+                ->color('danger')
+                ->actions([
+                    RestoreArticleAction::make()->icon('heroicon-m-arrow-uturn-left'),
+                    ForceDeleteAction::make()->icon('heroicon-o-trash'),
+                ]);
     }
 
     /**

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Services\ViewCounterService;
-use App\States\Articles;
 use App\Builders\ArticleBuilder;
 use App\Models\Relations\HasNotables;
-use App\Contracts\States\ArticleStateContract;
 use App\Enums\ArticleStates;
 use App\Enums\DataOrigin;
 use App\Enums\LanguageStatus;
+use App\Models\Concerns\Articles\ManagesArticleStates;
 use App\Models\Concerns\ManagesArticleAudits;
 use App\Models\Relations\Articles\HasCorrectionSupport;
 use App\Models\Relations\BelongsToAuthor;
@@ -102,6 +101,7 @@ final class Article extends Model implements AuditableContract, Commentable
     use HasComments;
     use Votable;
     use HasCorrectionSupport;
+    use ManagesArticleStates;
 
     /**
      * Relations that are always eager-loaded with this model.
@@ -140,28 +140,9 @@ final class Article extends Model implements AuditableContract, Commentable
         'migration_configuration' => '{"examples": true}',
     ];
 
-    /**
-     * Returns the appropriate Article State instance based on the current article status.
-     *
-     * This method uses a `match` expression to determine the current state of the dictionary article based on its state.
-     * It then returns an instance of the corresponding state class, which handles specific behaviors and transitions of that state.
-     * Each article state maps to a different state class; ensuring the current state logic is applied at any given point in the article lifecycle.
-     *
-     * Example states flow: New -> Draft -> Approval -> Published -> Archived
-     *
-     * @return ArticleStateContract - The corresponding state class for the current dictionary article
-     */
-    public function articleStatus(): ArticleStateContract
+    public function rejectedBy(): BelongsTo
     {
-        return match ($this->state) {
-            ArticleStates::ExternalData => new Articles\ExternalData($this),
-            ArticleStates::New => new Articles\Suggestion($this),
-            ArticleStates::Draft => new Articles\Draft($this),
-            ArticleStates::Approval => new Articles\Approval($this),
-            ArticleStates::Published => new Articles\Published($this),
-            ArticleStates::Archived => new Articles\Archived($this),
-            ArticleStates::RejectedPublication => new Articles\RejectedPublication($this)
-        };
+        return $this->belongsTo(User::class, 'rejected_by');
     }
 
     /**

--- a/app/Models/Concerns/Articles/ManagesArticleStates.php
+++ b/app/Models/Concerns/Articles/ManagesArticleStates.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns\Articles;
+
+use App\Enums\ArticleStates;
+use App\Contracts\States\ArticleStateContract;
+use App\States\Articles\ArticleState;
+use App\States\Articles;
+
+trait ManagesArticleStates
+{
+    /**
+     * Returns the appropriate Article State instance based on the current article status.
+     *
+     * This method uses a `match` expression to determine the current state of the dictionary article based on its state.
+     * It then returns an instance of the corresponding state class, which handles specific behaviors and transitions of that state.
+     * Each article state maps to a different state class; ensuring the current state logic is applied at any given point in the article lifecycle.
+     *
+     * Example states flow: New -> Draft -> Approval -> Published -> Archived
+     *
+     * @return ArticleStateContract - The corresponding state class for the current dictionary article
+     */
+    public function articleStatus(): ArticleStateContract
+    {
+        return match ($this->state) {
+            ArticleStates::ExternalData => new Articles\ExternalData($this),
+            ArticleStates::New => new Articles\Suggestion($this),
+            ArticleStates::Draft => new Articles\Draft($this),
+            ArticleStates::Approval => new Articles\Approval($this),
+            ArticleStates::Published => new Articles\Published($this),
+            ArticleStates::Archived => new Articles\Archived($this),
+            ArticleStates::RejectedPublication => new Articles\RejectedPublication($this),
+            ArticleStates::RejectedSuggestion => new Articles\RejectedSuggestion($this)
+        };
+    }
+
+    public function isAwaitingModeration(): bool
+    {
+        return $this->state->is(ArticleStates::New);
+    }
+
+    public function isRejectedSuggestion(): bool
+    {
+        return $this->state->is(ArticleStates::RejectedSuggestion);
+    }
+}

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -48,6 +48,7 @@ final class ArticlePolicy
         "updatePublished",
         "geforceerdVerwijderen",
         "meerdereGeforceerdVerwijderen",
+        "reject"
     ];
 
     /**
@@ -75,6 +76,15 @@ final class ArticlePolicy
 
         //! No custom authorization message defined because we simply need to return a HTTP 404 code.
         return Response::denyAsNotFound();
+    }
+
+    public function rejectSuggestion(User $user, Article $article): Response
+    {
+        if ($user->can('reject:article') && $article->isAwaitingModeration()) {
+            return Response::allow();
+        }
+
+        return Response::deny(message: __('U hebt geen machtiging om de suggestie van de gebruiker af te wijzen.'));
     }
 
     public function viewSuggestion(User $user, Article $article): Response

--- a/app/States/Articles/ArticleState.php
+++ b/app/States/Articles/ArticleState.php
@@ -85,4 +85,9 @@ class ArticleState implements ArticleStateContract
     {
         throw new LogicException('The method transitionToRejectedPublication() is not allowed on the current state.');
     }
+
+    public function transitionToRejectedSuggestion(array $feedback): bool
+    {
+        throw new LogicException('The method transitionToRejectedSuggestion() is not allowed on the current state.');
+    }
 }

--- a/app/States/Articles/RejectedSuggestion.php
+++ b/app/States/Articles/RejectedSuggestion.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\States\Articles;
+
+final class RejectedSuggestion extends ArticleState {}

--- a/app/States/Articles/Suggestion.php
+++ b/app/States/Articles/Suggestion.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\States\Articles;
 
+use App\Concerns\HandlesDatabaseTransactions;
 use App\Enums\ArticleStates;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Override;
 use Throwable;
 
 /**
@@ -21,6 +24,8 @@ use Throwable;
  */
 final class Suggestion extends ArticleState
 {
+    use HandlesDatabaseTransactions;
+
     /**
      * Transitions the article from the New state to a state that permits editing.
      *
@@ -40,6 +45,21 @@ final class Suggestion extends ArticleState
             $this->article->setCurrentUserAsEditor();
 
             return true;
+        });
+    }
+
+    /**
+     * @template TReturn
+     * @return TReturn
+     */
+    public function transitionToRejectedSuggestion(array $feedback): bool
+    {
+        return $this->executeInTransaction(function () use ($feedback): bool {
+            return $this->article->update(attributes: [
+                'state' => ArticleStates::RejectedSuggestion,
+                'rejected_by' => Auth::user()->getAuthIdentifier(),
+                'rejection_reason' => $feedback['rejection_reason'],
+            ]);
         });
     }
 }

--- a/database/migrations/2026_07_21_211525_add_rejection_support_for_articles.php
+++ b/database/migrations/2026_07_21_211525_add_rejection_support_for_articles.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('articles',  static function (Blueprint $table): void {
+            $table->after('archiever_id', function () use ($table): void {
+                $table->foreignIdFor(User::class, 'rejected_by')->nullable()->constrained()->nullOnDelete();
+            });
+
+            $table->after('archiving_reason', function () use ($table): void {
+                $table->string('rejection_reason')->nullable();
+            });
+        });
+    }
+};

--- a/resources/views/suggestions/show.blade.php
+++ b/resources/views/suggestions/show.blade.php
@@ -379,132 +379,202 @@
 
 
             <div class="row g-3">
-                <div class="col-6">
-                    <div class="card bg-light card-body h-100">
-                        <h6 class="fw-bold">Woordsoort</h5>
-                        <p class="text-light-emphasis">{{ $article->partOfSpeech->name ?? '- niet opgegeven' }}</p>
-                    </div>
-                </div>
-
-                <div class="col-6">
-                    <div class="card bg-light card-body h-100">
-                        <h6 class="fw-bold">Kenmerken</h5>
-                        <p class="text-light-emphasis">
-                            {{ $article->characteristics ?? '-niet opgegeven ' }}
-                        </p>
-                    </div>
-                </div>
-
-
                 <div class="col-12">
-                    <div class="card bg-light card-body">
-                        <h6 class="fw-bold">Regio(s)</h5>
-                        <p class="text-light-emphasis">
-                            @foreach ($article->regions as $region)
-                                <span @if (!$loop->first) class="me-1" @endif>{{ $region->name }},</span>
-                            @endforeach
-                        </p>
-                    </div>
-                </div>
+                    <ul class="nav nav-tabs" id="myTab" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home" type="button" role="tab" aria-controls="home" aria-selected="true">
+                                <x-tabler-info-square-rounded class="icon me-1"/> Informatie
+                            </button>
+                        </li>
 
-                <div class="col-12">
-                    <div class="card bg-light card-body">
-                        <h6 class="fw-bold">Beschrijving</h5>
-
-                        <div class="text-light-emphasis">
-                            {!! str($article->description)->markdown()->sanitizeHtml() !!}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-12">
-                    <div class="card bg-light card-body">
-                        <h6 class="fw-bold">Voorbeeldzinnen</h6>
-
-                        @if ($article->userExamples()->exists())
-                            <ul class="mb-0 list-unstyled space-y-4">
-                                @foreach ($article->userExamples as $example)
-                                    <li class="break-words @if (! $loop->last) pb-3 border-bottom mb-3 @endif">
-                                        {{-- Main Sentence --}}
-                                        <div class="text-gray-900">
-                                            <span class="badge rounded-pill bg-dark text-white">{{ $loop->iteration }}</span>
-                                            <span class="ms-2">{{ $example->example }}</span>
-                                        </div>
-
-                                        {{-- Source Media Object --}}
-                                        <div class="d-flex align-items-center text-muted small ms-4">
-                                            <cite class="italic ms-1">bron: {{ $example->source }}</cite>
-                                        </div>
-                                    </li>
-                                @endforeach
-                            </ul>
+                        @if ($article->isRejectedSuggestion())
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#profile" type="button" role="tab" aria-controls="profile" aria-selected="false">
+                                    <x-tabler-message-report class="icon me-1"/> Reden voor afwijzing
+                                </button>
+                            </li>
                         @endif
+                    </ul>
+                </div>
+
+                <div class="tab-content" id="myTabContent">
+                    @if ($article->isRejectedSuggestion())
+                        <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">
+                            <div class="row g-3">
+                                <div class="col-12">
+                                    <div class="card bg-light border card-body h-100">
+                                        <p class="text-light-emphasis">
+                                            {{ $article->rejection_reason }}
+                                        </p>
+
+                                        <hr class="my-2">
+
+                                            <ul class="list-inline mb-0 small text-light-emphasis">
+                                                <li class="list-inline-item me-4">
+                                                    <span class="text-dark" class="me-1">
+                                                        <x-heroicon-o-user-circle class="color-green icon me-1"/> Beoordeeld door:
+                                                    </span>
+
+                                                    <strong class="fw-bold me-1">
+                                                        {{ $article->rejectedBy->name ?? 'Onbekende gebruiker' }}
+                                                    </strong>
+                                                </li>
+
+                                                <li class="list-inline-item">
+                                                    <span class="text-dark" class="me-1">
+                                                        <x-heroicon-o-clock class="color-green icon me-1"/> Beoordeeld op:
+                                                    </span>
+
+                                                    <strong class="fw-bold me-1">
+                                                        {{ $article->updated_at->translatedFormat('d M, Y') }}
+                                                        <span class="fst-italic">({{ $article->updated_at->diffForHumans() }})</span>
+                                                    </strong>
+                                                </li>
+                                            </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+
+                    <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                         <div class="row g-3">
+                            <div class="col-6">
+                                <div class="card bg-light card-body h-100">
+                                    <h6 class="fw-bold">Woordsoort</h5>
+                                    <p class="text-light-emphasis">{{ $article->partOfSpeech->name ?? '- niet opgegeven' }}</p>
+                                </div>
+                            </div>
+
+                            <div class="col-6">
+                                <div class="card bg-light card-body h-100">
+                                    <h6 class="fw-bold">Kenmerken</h5>
+                                    <p class="text-light-emphasis">
+                                        {{ $article->characteristics ?? '-niet opgegeven ' }}
+                                    </p>
+                                </div>
+                            </div>
+
+
+                            <div class="col-12">
+                                <div class="card bg-light card-body">
+                                    <h6 class="fw-bold">Regio(s)</h5>
+                                    <p class="text-light-emphasis">
+                                        @foreach ($article->regions as $region)
+                                            <span @if (!$loop->first) class="me-1" @endif>{{ $region->name }},</span>
+                                        @endforeach
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="col-12">
+                                <div class="card bg-light card-body">
+                                    <h6 class="fw-bold">Beschrijving</h6>
+
+                                    <div class="text-light-emphasis">
+                                        {!! str($article->description)->markdown()->sanitizeHtml() !!}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="col-12">
+                                <div class="card bg-light card-body">
+                                    <h6 class="fw-bold">Voorbeeldzinnen</h6>
+
+                                    @if ($article->userExamples()->exists())
+                                        <ul class="mb-0 list-unstyled space-y-4">
+                                            @foreach ($article->userExamples as $example)
+                                                <li class="@if (! $loop->last) pb-3 border-bottom mb-3 @endif">
+                                                    <div class="d-flex align-items-start">
+                                                        {{-- Badge --}}
+                                                        <span class="badge rounded-pill bg-dark text-white me-3 mt-1 flex-shrink-0">{{ $loop->iteration }}</span>
+
+                                                        {{-- Content Container with text-break to handle long strings --}}
+                                                        <div class="flex-grow-1 text-break">
+                                                            {{-- Main Sentence --}}
+                                                            <div class="text-gray-900">
+                                                                <span>{{ $example->example }}</span>
+                                                            </div>
+
+                                                            {{-- Source Media Object --}}
+                                                            <div class="d-flex align-items-center text-muted small mt-1">
+                                                                <cite class="italic">bron: {{ $example->source }}</cite>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                    @endif
+                                </div>
+                            </div>
+
+                            @if ($article->editor || $article->archiever || $article->publisher)
+                                <hr>
+
+                                <div class="row">
+                                    @if ($article->editor)
+                                        <div class="col-4">
+                                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
+                                                Redactie door
+                                            </span>
+
+                                            <div class="card bg-white border rounded-4 p-3">
+                                                <div class="d-flex align-items-center">
+                                                    <img src="{{ $article->editor->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
+
+                                                    <div class="ms-3 flex-grow-1">
+                                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->editor->name ?? config('app.name', 'Laravel') }}</h6>
+                                                        <div class="text-muted small">{{ $article->editor->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @endif
+
+                                    @if ($article->publisher)
+                                        <div class="col-4">
+                                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
+                                                Eindredactie door
+                                            </span>
+
+                                            <div class="card bg-white border rounded-4 p-3">
+                                                <div class="d-flex align-items-center">
+                                                    <img src="{{ $article->publisher->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
+
+                                                    <div class="ms-3 flex-grow-1">
+                                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->publisher->name ?? config('app.name', 'Laravel') }}</h6>
+                                                        <div class="text-muted small">{{ $article->publisher->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @endif
+
+                                    @if ($article->archiever)
+                                        <div class="col-4">
+                                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
+                                                Gearchiveerd door
+                                            </span>
+
+                                            <div class="card bg-white border rounded-4 p-3">
+                                                <div class="d-flex align-items-center">
+                                                    <img src="{{ $article->archiever->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
+
+                                                    <div class="ms-3 flex-grow-1">
+                                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->archiever->name ?? config('app.name', 'Laravel') }}</h6>
+                                                        <div class="text-muted small">{{ $article->archiever->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @endif
+                                </div>
+                            @endif
+                        </div>
                     </div>
                 </div>
             </div>
-
-            @if ($article->editor || $article->archiever || $article->publisher)
-                <hr>
-
-                <div class="row">
-                    @if ($article->editor)
-                        <div class="col-4">
-                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
-                                Redactie door
-                            </span>
-
-                            <div class="card bg-white border rounded-4 p-3">
-                                <div class="d-flex align-items-center">
-                                    <img src="{{ $article->editor->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
-
-                                    <div class="ms-3 flex-grow-1">
-                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->editor->name ?? config('app.name', 'Laravel') }}</h6>
-                                        <div class="text-muted small">{{ $article->editor->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
-
-                    @if ($article->publisher)
-                        <div class="col-4">
-                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
-                                Eindredactie door
-                            </span>
-
-                            <div class="card bg-white border rounded-4 p-3">
-                                <div class="d-flex align-items-center">
-                                    <img src="{{ $article->publisher->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
-
-                                    <div class="ms-3 flex-grow-1">
-                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->publisher->name ?? config('app.name', 'Laravel') }}</h6>
-                                        <div class="text-muted small">{{ $article->publisher->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
-
-                    @if ($article->archiever)
-                        <div class="col-4">
-                            <span class="text-uppercase text-muted fw-bold small mb-2 d-block" style="letter-spacing: 0.5px;">
-                                Gearchiveerd door
-                            </span>
-
-                            <div class="card bg-white border rounded-4 p-3">
-                                <div class="d-flex align-items-center">
-                                    <img src="{{ $article->archiever->getFilamentAvatarUrl() }}" class="rounded-circle bg-light d-flex align-items-center justify-content-center shadow-sm" style="width: 33px; height: 33px; flex-shrink: 0;"/>
-
-                                    <div class="ms-3 flex-grow-1">
-                                        <h6 class="mb-0 fw-bold text-dark">{{ $article->archiever->name ?? config('app.name', 'Laravel') }}</h6>
-                                        <div class="text-muted small">{{ $article->archiever->user_type->getLabel() ?? 'Verwijderde gebruiker' }}</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
-                </div>
-            @endif
         </div>
     </div>
 </div>


### PR DESCRIPTION
Deze PR introduceert een nieuwe `RejectedSuggestion` state binnen de levenscyclus van artikelen, waarmee redacteurs ingediende suggesties van gebruikers formeel kunnen afwijzen en voorzien van schriftelijke feedback. De implementatie dekte de volledige stack: database schema, state machine, autorisatie, Filament beheeractie en de publieke suggestie pagina.
 
## Context & motivatie

Tot nu toe konden redacteurs alleen reageren op ingediende suggesties door ze goed te keuren of te archiveren. Er was geen formele manier om een suggestie af te wijzen met uitleg richting de indiender. Dit zorgde voor onduidelijkheid bij gebruikers van wie de suggestie niet werd goedgekeurd. Met deze wijziging krijgt het redactieteam een duidelijke tool en ontvangt de indiener zinvolle feedback over de reden van afwijzing. 

--- 

## Wijzigingen per laag 

### Database 

- Nieuwe migratie (`2026_07_21_211525_add_rejection_support_for_articles.php`) voegt twee kolommen toe aan de `articles` tabel:
  - `rejected_by`: nullable foreign key naar `users`, met `nullOnDelete()`
  - `rejection_reason`: nullable string voor de afwijzingsreden

#### Enums & Toestandsmachine
- `RejectedSuggestion = 7` toegevoegd aan `ArticleStates` met:
  - Nederlands label: *Afgewezen suggestie*
  - Beschrijving: *Suggesties voor artikelen die zijn afgewezen door het redactieteam*
  - Kleur: `danger` (rood), in lijn met `Archived` en `RejectedPublication`
- `transitionToRejectedSuggestion(array $feedback)` toegevoegd aan `ArticleStateContract`
- Basisimplementatie in `ArticleState` gooit een `LogicException` — enkel de `Suggestion`-staat overschrijft dit
- `Suggestion`-staat implementeert de overgang: werkt `state`, `rejected_by` en `rejection_reason` bij binnen een databasetransactie
- Nieuwe terminale staat `RejectedSuggestion` aangemaakt (geen verdere overgangen mogelijk)
#### Model Refactor
- `articleStatus()` en gerelateerde hulpmethoden zijn verplaatst van `Article` naar de nieuwe trait `ManagesArticleStates` (`app/Models/Concerns/Articles/`), waardoor het model overzichtelijker wordt
- Twee nieuwe hulpmethoden toegevoegd:
  - `isAwaitingModeration()` — controleert of het artikel de staat `New` heeft
  - `isRejectedSuggestion()` — controleert of het artikel de staat `RejectedSuggestion` heeft
- `rejectedBy()` BelongsTo-relatie toegevoegd aan `Article`
#### Autorisatie
- Nieuwe `rejectSuggestion`-methode toegevoegd aan `ArticlePolicy`
- Staat enkel gebruikers met de `reject:article`-machtiging toe, én alleen wanneer het artikel momenteel de staat `New` heeft
- Geeft anderzijds een duidelijke Nederlandstalige foutmelding terug
#### Filament Beheeractie
- Nieuwe `RejectSuggestionAction` toegevoegd aan de actiegroep op de artikelweergavepagina
- Opent een bevestigingsmodal met een verplicht tekstveld voor de afwijzingsreden
- Sluit na bevestiging de actie af met een succesmelding: *"De suggestie is met succes afgewezen"*
- Toont een foutmelding als de overgang mislukt
#### Infolist (Beheerdersdashboard)
- Inline alertcomponenten in `WordInfolist` zijn geherstructureerd naar private statische methoden:
  - `archivedAlert()` — melding bij gearchiveerde artikelen
  - `deleteAlert()` — melding bij verwijderde artikelen
  - `rejectedSuggestionAlert()` — nieuwe melding bij afgewezen suggesties
- De nieuwe alert toont: naam van de afwijzende redacteur, relatieve tijdsaanduiding en de opgegeven afwijzingsreden
#### Publieke Suggestiepagina (`suggestions/show.blade.php`)
- Artikeldetails zijn onderverdeeld in Bootstrap-tabbladen
- Wanneer een artikel de staat `RejectedSuggestion` heeft, verschijnt automatisch een tweede tabblad *"Reden voor afwijzing"* met:
  - De afwijzingsreden in leesbare vorm
  - De naam van de beoordelende redacteur
  - Datum en relatieve tijdsaanduiding van de beoordeling
---
 
### Artikellevenscyclus (bijgewerkt)
 
```
New ──► Draft ──► Approval ──► Published ──► Archived
 │
 └──► RejectedSuggestion  ← nieuw
```
 
---
 
### Testchecklist
 
- [ ] Migratie verloopt foutloos (`php artisan migrate`)
- [ ] Een artikel met staat `New` kan worden afgewezen via de beheeractie
- [ ] Afwijzingsreden en beoordelaar worden correct opgeslagen
- [ ] Succesmelding verschijnt na afwijzing in het beheerderspaneel
- [ ] De `rejectSuggestion`-policy blokkeert gebruikers zonder `reject:article`-machtiging
- [ ] De `rejectSuggestion`-policy blokkeert artikelen die niet de staat `New` hebben
- [ ] Afwijzingsalert verschijnt correct in de Filament-infolist
- [ ] Het tabblad *"Reden voor afwijzing"* is enkel zichtbaar bij afgewezen suggesties op de publieke pagina
- [ ] `transitionToRejectedSuggestion()` gooit een `LogicException` op niet-`Suggestion`-staten
- [ ] `isRejectedSuggestion()` en `isAwaitingModeration()` geven correct `true`/`false` terug
---
 
### Opmerkingen
 
- De `RejectedSuggestion`-staat is bewust een terminale staat — er is geen herstelmogelijkheid voorzien in deze PR. Indien gewenst kan een aparte PR een *"terug naar concept"*-overgang toevoegen.
- De `getDescription()`-methode in `ArticleStates` mist nog een geval voor `ExternalData` en `Suggestion` — dit is bestaande technische schuld en valt buiten de scope van deze PR.