### PR TITLE
feat: suggestie wachtrij uitbreiden met tabs (onbehandeld/kladartikelen/afgewezen)

### DIFF
--- a/app/Builders/ArticleBuilder.php
+++ b/app/Builders/ArticleBuilder.php
@@ -7,7 +7,9 @@ namespace App\Builders;
 use App\Models\Article;
 use Throwable;
 use App\Enums\ArticleStates;
+use App\Models\User;
 use App\Notifications\SendoutPublicationNotification;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -57,6 +59,16 @@ final class ArticleBuilder extends Builder
     public function archived(): Builder
     {
         return $this->orWhereNotNull("archived_at");
+    }
+
+    #[Scope]
+    public function forEditor(User|int $editor): Builder
+    {
+        $editorId = $editor instanceof User
+            ? $editor->id
+            : $editor;
+
+        return $this->where('editor_id', $editorId);
     }
 
     public function isEditable(): bool

--- a/app/Filament/Pages/SuggestionQueueDashboard.php
+++ b/app/Filament/Pages/SuggestionQueueDashboard.php
@@ -9,6 +9,9 @@ use App\Filament\Resources\Articles\Widgets\SuggestionQueueTable;
 use App\Models\Article;
 use BackedEnum;
 use Filament\Pages\Dashboard;
+use Filament\Resources\Concerns\HasTabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Override;
 
 final class SuggestionQueueDashboard extends Dashboard
 {
@@ -16,9 +19,11 @@ final class SuggestionQueueDashboard extends Dashboard
 
     protected static ?string $cluster = ArticlesCluster::class;
 
+    protected static ?int $navigationSort = -5;
+
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
 
-    protected static ?string $title = 'Suggestie wachtrij';
+    protected static ?string $title = 'Het redactiekot';
 
     /**
      * @return string[]
@@ -29,12 +34,5 @@ final class SuggestionQueueDashboard extends Dashboard
             SuggestionQueueKpiStats::class,
             SuggestionQueueTable::class,
         ];
-    }
-
-    public static function getNavigationBadge(): string
-    {
-        return (string) Article::where('state', ArticleStates::New)
-            ->orWhere('state', ArticleStates::ExternalData)
-            ->count();
     }
 }

--- a/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
@@ -73,6 +73,10 @@ final class DuplicationArticleAction extends Action
                     $newArticle->sources()->save($source);
                 }
 
+                foreach ($article->userExamples as $sentence) {
+                    $newArticle->userExamples()->save($sentence);git kel
+                }
+
                 $this->newArticleInstance = $newArticle; // Store the article
                 return true;
 

--- a/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
+++ b/app/Filament/Resources/Articles/Actions/DuplicationArticleAction.php
@@ -74,7 +74,7 @@ final class DuplicationArticleAction extends Action
                 }
 
                 foreach ($article->userExamples as $sentence) {
-                    $newArticle->userExamples()->save($sentence);git kel
+                    $newArticle->userExamples()->save($sentence);
                 }
 
                 $this->newArticleInstance = $newArticle; // Store the article

--- a/app/Filament/Resources/Articles/Widgets/SuggestionQueueTable.php
+++ b/app/Filament/Resources/Articles/Widgets/SuggestionQueueTable.php
@@ -1,41 +1,69 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\Articles\Widgets;
 
 use App\Enums\ArticleStates;
-use App\Filament\Clusters\Volunteers\Resources\VolunteerApplications\Actions\ViewAction;
 use App\Filament\Resources\Articles\ArticleResource;
 use App\Models\Article;
+use App\Models\User;
 use Deldius\UserField\UserColumn;
 use Filament\Actions\Action;
-use Filament\Actions\EditAction;
-use Filament\Support\Enums\FontWeight;
 use Filament\Support\Icons\Heroicon;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget;
 use Illuminate\Database\Eloquent\Builder;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use LogicException;
 
 class SuggestionQueueTable extends TableWidget
 {
+    public const unprocessed = 'unprocessed';
+    public const draft = 'draft';
+    public const rejected = 'rejected';
+
+    public string $activeTab = self::unprocessed;
+
     protected int|string|array $columnSpan = 'full';
+
+    public function updatedActiveTab(): void
+    {
+        $this->resetTable();
+    }
 
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => ArticleResource::getEloquentQuery()->whereIn('state', [ArticleStates::New , ArticleStates::ExternalData]))
-            ->heading('Nieuwe suggesties')
-            ->emptyStateIcon(Heroicon::OutlinedInbox)
-            ->emptyStateHeading('Geen Suggesties gevonden')
-            ->emptyStateDescription('Momenteel zijn alle suggesties in behandeling of zijn er geen suggesties gevonden die matchen met je zoek term')
-            ->description('Een kort overzicht van nieuwe suggesties die zijn binnengekomen en opgenomen kunnen worden door een (eind)redacteur. Suggesties die al geclaimd zijn kunnen bekeken worden in het woordenboek overzicht')
-            ->recordUrl(fn (Article $article): string => ArticleResource::getUrl('view', ['record' => $article]))
-            ->headerActions(actions: $this->getHeaderActions())
-            ->columns(components: $this->tableLayoutColumns())
+            ->query(fn (): Builder => $this->currentTab()['query']($this->baseQuery()))
+            ->headerActions($this->getHeaderActions())
+            ->heading($this->currentTab()['heading'])
+            ->description($this->currentTab()['description'])
+            ->emptyStateIcon($this->currentTab()['icon'])
+            ->emptyStateHeading($this->currentTab()['emptyStateHeading'])
+            ->emptyStateDescription($this->currentTab()['emptyStateDescription'])
             ->recordActions(actions: $this->registerToolbarActions())
             ->filters(filters: $this->registerFilters())
+            ->recordUrl(fn (Article $article): string => ArticleResource::getUrl('view', ['record' => $article]))
+            ->columns($this->tableLayoutColumns())
             ->paginated([7, 14, 21, 28]);
+    }
+
+    public function render(): \Illuminate\View\View
+    {
+        return view('filament.widgets.suggestion-queue-table', [
+            'tabs' => collect($this->tabs())
+                ->map(fn (array $tab) => [
+                    'label' => $tab['menuLabel'],
+                    'badge' => $tab['query']($this->baseQuery())->count(),
+                    'icon' => $tab['icon'],
+                ])
+                ->all(),
+        ]);
     }
 
     /**
@@ -50,6 +78,8 @@ class SuggestionQueueTable extends TableWidget
                 ->options([
                     ArticleStates::New ->value => ArticleStates::New ->getLabel(),
                     ArticleStates::ExternalData->value => ArticleStates::ExternalData->getLabel(),
+                    ArticleStates::Draft->value => ArticleStates::Draft->getLabel(),
+                    ArticleStates::RejectedPublication->value => ArticleStates::RejectedPublication->getLabel(),
                 ])
         ];
     }
@@ -69,9 +99,6 @@ class SuggestionQueueTable extends TableWidget
         ];
     }
 
-    /**
-     * @return array<TextColumn|UserColumn>
-     */
     private function tableLayoutColumns(): array
     {
         return [
@@ -101,19 +128,82 @@ class SuggestionQueueTable extends TableWidget
     }
 
     /**
-     * @return Action[]
+     * Single source of truth for every tab: menu label, heading, icon,
+     * and the query filter applied on top of the base editor query.
+     *
+     * @return array<string, array{menuLabel: string, heading: string, icon: Heroicon, query: \Closure(Builder): Builder}>
      */
-    private function getHeaderActions(): array
+    private function tabs(): array
     {
         return [
-            Action::make('Artikel toevoegen')
-                ->icon(Heroicon::OutlinedDocumentPlus)
-                ->url(ArticleResource::getUrl('create'))
-                ->color('gray'),
+            self::unprocessed => [
+                'menuLabel' => 'Onbehandelde suggesties',
+                'emptyStateHeading' => 'Geen onbehandelde suggesties gevonden',
+                'emptyStateDescription' => 'het lijkt erop dat we weer helemaal mee zijn met de artikelen van het Vlaams Woordenboek! Kom later nog eens terug',
+                'heading' => __('Suggestie wachtrij'),
+                'description' => 'Alle door gebruikers ingediende suggesties die wachten op behandeld te worden.',
+                'icon' => Heroicon::OutlinedQueueList,
+                'query' => fn (Builder $query): Builder => $query
+                    ->whereIn('state', [ArticleStates::New, ArticleStates::ExternalData]),
+            ],
 
-            Action::make('artikelen overzicht')
-                ->icon(Heroicon::BookOpen)
-                ->url(ArticleResource::getUrl('index'))
+            self::draft => [
+                'menuLabel' => 'Mijn Kladartikelen',
+                'emptyStateHeading' => 'Geen kladartikelen gevonden',
+                'emptyStateDescription' => 'Het lijkt erop dat je momenteel geen artikelen hebt die je actief aan het bewerken bent',
+                'heading' => __('Mijn kladartikelen'),
+                'description' => 'Een overzicht van alle artikelen die je hebt gekozen om te bewerken',
+                'icon' => Heroicon::OutlinedPencilSquare,
+                'query' => fn (Builder $query): Builder => $query
+                    ->forEditor($this->user())
+                    ->where('state', ArticleStates::Draft),
+            ],
+
+            self::rejected => [
+                'menuLabel' => 'Mijn afgewezen publicaties',
+                'heading' => __('Mijn afgewezen publicaties'),
+                'emptyStateHeading' => 'Geen afgewezen publicaties gevonden',
+                'emptyStateDescription' => 'Het lijkt er op dat je momenteel geen artikelen hebt staan die verdere verfijning nodig hebben.',
+                'description' => 'Overzicht van alle artikelen die net iets meer verfijning nodig hebben alvorens ze gepubliceerd worden',
+                'icon' => Heroicon::OutlinedXCircle,
+                'query' => fn (Builder $query): Builder => $query
+                    ->forEditor($this->user())
+                    ->where('state', ArticleStates::RejectedPublication),
+            ],
         ];
+    }
+
+    private function currentTab(): array
+    {
+        return $this->tabs()[$this->activeTab]
+            ?? throw new LogicException("Unknown tab [{$this->activeTab}].");
+    }
+
+    private function getHeaderActions(): ?array
+    {
+        if (in_array($this->activeTab, [self::unprocessed, self::draft])) {
+            return [
+                Action::make('create-article-action')
+                    ->label('Artikel toevoegen')
+                    ->color('gray')
+                    ->icon(Heroicon::OutlinedDocumentPlus)
+                    ->url(ArticleResource::getUrl('create'))
+            ];
+        }
+
+        return [];
+    }
+
+    private function baseQuery(): Builder
+    {
+        return ArticleResource::getEloquentQuery();
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user;
     }
 }

--- a/resources/views/filament/widgets/suggestion-queue-table.blade.php
+++ b/resources/views/filament/widgets/suggestion-queue-table.blade.php
@@ -1,0 +1,16 @@
+<x-filament-widgets::widget>
+    <x-filament::tabs class="mb-4">
+        @foreach ($tabs as $key => $tab)
+            <x-filament::tabs.item
+                :active="$activeTab === $key"
+                :badge="$tab['badge']"
+                :icon="$tab['icon'] ?? null"
+                wire:click="$set('activeTab', '{{ $key }}')"
+            >
+                {{ $tab['label'] }}
+            </x-filament::tabs.item>
+        @endforeach
+    </x-filament::tabs>
+
+    {{ $this->table }}
+</x-filament-widgets::widget>


### PR DESCRIPTION
Deze PR breidt het `SuggestionQueueDashboard` widget uit met een tab-navigatie, zodat redacteurs naast de onbehandelde suggesties nu ook eigen kladartikelen en afgewezen publicaties in hetzelfde overzicht kunnen terugvinden. 

Deze PR breidt het `SuggestionQueueDashboard` widget uit met een tab-navigatie, zodat redacteurs naast de onbehandelde suggesties nu ook hun eigen kladartikelen en afgewezen publicaties in hetzelfde overzicht kunnen terugvinden.

## Wijzigingen

### `ArticleBuilder.php`
- Nieuwe query scope `forEditor(User|int $editor)` toegevoegd om artikelen te filteren op de toegewezen editor.

### `SuggestionQueueDashboard.php`
- `navigationSort` toegevoegd zodat de pagina hoger in de navigatie verschijnt.
- Titel aangepast van *"Suggestie wachtrij"* naar *"Het redactiekot"*.
- `getNavigationBadge()` verwijderd (het aantal wordt nu per tab getoond in het widget zelf i.p.v. op de navigatie-badge).

### `SuggestionQueueTable.php`
- Widget volledig omgebouwd naar een tab-gebaseerde tabel met drie tabs:
  - **Onbehandelde suggesties** — artikelen met state `New` of `ExternalData`.
  - **Mijn kladartikelen** — eigen artikelen met state `Draft`.
  - **Mijn afgewezen publicaties** — eigen artikelen met state `RejectedPublication`.
- Elke tab heeft een eigen heading, beschrijving, empty state en icoon, gecentraliseerd in de `tabs()`-methode als single source of truth.
- `render()` override toegevoegd om de tabs (met live badge-counts) door te geven aan de blade view.
- `updatedActiveTab()` reset de tabel bij het wisselen van tab.
- Filters uitgebreid met `Draft` en `RejectedPublication` states.
- "Artikel toevoegen"-actie wordt enkel getoond op de tabs waar dat relevant is (onbehandeld/kladartikelen), niet bij afgewezen publicaties.
- Kleine opruiming: `declare(strict_types=1)` toegevoegd, imports gecorrigeerd (juiste `EditAction`/`ViewAction` uit Filament i.p.v. een verkeerde import uit de Volunteers-cluster).

### Nieuw: `suggestion-queue-table.blade.php`
- View toegevoegd die de tabs rendert via `x-filament::tabs`, inclusief badges en iconen per tab, gevolgd door de eigenlijke tabel.

## Testen
- [ ] Handmatig gecontroleerd dat elke tab de juiste artikelen toont voor de ingelogde editor.
- [ ] Gecontroleerd dat badges correct het aantal artikelen per tab weergeven.
- [ ] Gecontroleerd dat "Artikel toevoegen" niet verschijnt op de tab "Mijn afgewezen publicaties".

## Aandachtspunten voor reviewers
- `currentTab()` gooit een `LogicException` bij een onbekende tab-key — is dat gewenst gedrag of liever een fallback naar de eerste tab?
- De verwijderde `getNavigationBadge()` toonde voorheen het aantal *nieuwe* suggesties in de navigatie-sidebar; wil je dat ergens anders terug laten komen, of is de in-widget badge voldoende?