### PR TITLE
fix(#640): Bevestigingsbericht blokkeert formulier niet meer

### DIFF
--- a/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Pages/ViewPartOfSpeeches.php
+++ b/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Pages/ViewPartOfSpeeches.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Pages;
+
+use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\PartOfSpeechResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+use Filament\Support\Icons\Heroicon;
+use Override;
+
+final class ViewPartOfSpeeches extends ViewRecord
+{
+    protected static string $resource = PartOfSpeechResource::class;
+
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make()
+                ->icon(Heroicon::OutlinedPencilSquare),
+        ];
+    }
+}

--- a/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/PartOfSpeechResource.php
+++ b/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/PartOfSpeechResource.php
@@ -7,6 +7,7 @@ namespace App\Filament\Clusters\Articles\Resources\PartOfSpeeches;
 use App\Filament\Clusters\Articles\ArticlesCluster;
 use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Pages;
 use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Schemas\PartOfSpeechForm;
+use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Schemas\PartOfSpeechInfolist;
 use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Tables\PartOfSpeechesTable;
 use App\Models\PartOfSpeech;
 use BackedEnum;
@@ -92,6 +93,11 @@ final class PartOfSpeechResource extends Resource
         return PartOfSpeechesTable::configure($table);
     }
 
+    public static function infolist(Schema $schema): Schema
+    {
+        return PartOfSpeechInfolist::configure($schema);
+    }
+
     /**
      * Map the resource to specific pages.
      * Defines the URL strucutre and the correspondinbg Filament Page components used fo listing, creating, and editing records.
@@ -101,8 +107,8 @@ final class PartOfSpeechResource extends Resource
     public static function getPages(): array
     {
         return [
-            // 'shiw' => Pages\ViewPartOfSpeeches::route('/{record}'),
             'index' => Pages\ListPartOfSpeeches::route('/'),
+            'view' => Pages\ViewPartOfSpeeches::route('/{record}'),
         ];
     }
 }

--- a/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Schemas/PartOfSpeechInfolist.php
+++ b/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Schemas/PartOfSpeechInfolist.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Schemas;
+
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\IconSize;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+
+final class PartOfSpeechInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Algemene informatie')
+                    ->columns(12)
+                    ->description('Alle geregistreerde informatie omtrent de woordsoort')
+                    ->compact()
+                    ->columnSpanFull()
+                    ->columns(12)
+                    ->icon(Heroicon::InformationCircle)
+                    ->iconColor('primary')
+                    ->iconSize(IconSize::Medium)
+                    ->schema(self::getInfolistColumns()),
+            ]);
+    }
+
+    private static function getInfolistColumns(): array
+    {
+        return [
+            IconEntry::make('suggestible')
+                ->label('Suggestie formulier')
+                ->columnSpan(3)
+                ->boolean(),
+
+            TextEntry::make('value')
+                ->badge()
+                ->columnSpan(3)
+                ->label('Afkorting'),
+            TextEntry::make('name')
+                ->label('Woordsoort')
+                ->badge()
+                ->columnSpan(3),
+            TextEntry::make('created_at')
+                ->label('Aangemaakt op')
+                ->since()
+                ->columnSpan(3),
+        ];
+    }
+}

--- a/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Tables/PartOfSpeechesTable.php
+++ b/app/Filament/Clusters/Articles/Resources/PartOfSpeeches/Tables/PartOfSpeechesTable.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Tables;
 
+use App\Filament\Clusters\Articles\Resources\PartOfSpeeches\PartOfSpeechResource;
+use App\Models\PartOfSpeech;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
 use Filament\Support\Enums\FontWeight;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\IconColumn;
@@ -13,22 +17,22 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
 /**
- * Class PartOfSpeechesTable 
- * 
- * Provides a specialized configuration factory for the Filament Table Component. 
- * This class handles the administrative listing of parts of speech (woordsoorten) for the Flemish Dictionary, 
+ * Class PartOfSpeechesTable
+ *
+ * Provides a specialized configuration factory for the Filament Table Component.
+ * This class handles the administrative listing of parts of speech (woordsoorten) for the Flemish Dictionary,
  * ensuring a consistent data representation and user experience across the application's management cluster.
- * 
+ *
  * @package App\Filament\Clusters\Articles\Resources\PartOfSpeeches\Tables
  */
 final readonly class PartOfSpeechesTable
 {
     /**
-     * Configure the administrative data table. 
-     * 
-     * This method defines the full lifecycle of the table UI, including: 
-     * 
-     * - Table Metadata: Sets the localized headers and empty state instructions. 
+     * Configure the administrative data table.
+     *
+     * This method defines the full lifecycle of the table UI, including:
+     *
+     * - Table Metadata: Sets the localized headers and empty state instructions.
      * - Column Schema: Defines the visual data points like IDs, boolean status icons, searchable text fields for abbreviations and names, and aggregate counts for related articles.
      * - Interaction logic: Registers the primary actions available to users, such as editing records or performing authorized deletions.
      *
@@ -40,6 +44,7 @@ final readonly class PartOfSpeechesTable
         return $table
             ->heading(heading: __('Woordsoorten'))
             ->description(description: __('Overzicht van alle woordsoorten in het Vlaams Woordenboek'))
+            ->recordUrl(fn (PartOfSpeech $partOfSpeech): string => PartOfSpeechResource::getUrl('view', ['record' => $partOfSpeech]))
             ->emptyStateIcon(Heroicon::OutlinedListBullet)
             ->emptyStateHeading(heading: __('Geen woordsoorten gevonden'))
             ->emptyStateDescription(description: __('Momenteel zijn er geen woordsoorten geregistreerd of gevonden met je opgegeven zoekterm.'))
@@ -67,9 +72,13 @@ final readonly class PartOfSpeechesTable
                     ->sortable(),
             ])
             ->recordActions([
-                EditAction::make(),
-                DeleteAction::make()
-                    ->authorizationNotification(),
+                ViewAction::make(),
+
+                ActionGroup::make([
+                    EditAction::make(),
+                    DeleteAction::make()
+                        ->authorizationNotification(),
+                ]),
             ]);
     }
 }

--- a/resources/views/livewire/submit-user-example.blade.php
+++ b/resources/views/livewire/submit-user-example.blade.php
@@ -1,66 +1,72 @@
-<div>
-    @if ($submitted)
-        <div class="alert alert-success d-flex align-items-center gap-2 {{ $cssClasses }} mb-0">
-            <i class="bi bi-check-circle-fill"></i>
-            <span>Bedankt! Je voorbeeldzin werd ingediend en wordt nagekeken door onze redactie.</span>
-        </div>
-    @else
-        <div class="{{ $cssClasses }}">
-            @if (session()->has('example_error'))
-                <div class="alert alert-danger small py-2">{{ session('example_error') }}</div>
+   <div class="{{ $cssClasses }}">
+    @if (session()->has('example_error'))
+        <div class="alert alert-danger small py-2">{{ session('example_error') }}</div>
+    @endif
+
+    @auth
+        <div class="row">
+            @if ($submitted)
+                <div class="col-12 mb-2">
+                    <div class="p-2 alert alert-success d-flex align-items-center gap-2 {{ $cssClasses }} mb-0">
+                        <i class="bi bi-check-circle-fill"></i>
+                        <span>Bedankt! Je voorbeeldzin werd ingediend en wordt nagekeken door onze redactie.</span>
+                    </div>
+
+                    <hr class="mb-2">
+                </div>
             @endif
 
-            @auth
-                <div class="row">
-                    <div class="col-8 mb-2">
-                        <label for="source" class="visually-hidden-focusable">Bron vermelding</label>
-                        <input
-                            id="source"
-                            wire:model="source"
-                            class="form-control bg-white form-control-sm @error('source') is-invalid @enderror"
-                            placeholder="Vertel ons de link waar je de voorbeeldzin hebt gevonden"
-                        >
-                        @error('source')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
+            <div class="col-8 mb-2">
+                <label for="source" class="visually-hidden-focusable">Bron vermelding</label>
+                <input
+                    id="source"
+                    wire:model="source"
+                    class="form-control bg-white form-control-sm @error('source') is-invalid @enderror"
+                    placeholder="Vertel ons de link waar je de voorbeeldzin hebt gevonden"
+                >
 
-                    <div class="col-12 mb-2">
-                        <label for="example" class="visually-hidden-focusable">Voorbeeldzin</label>
-                        <textarea
-                            id="example"
-                            wire:model="example"
-                            class="form-control bg-white form-control-sm @error('example') is-invalid @enderror"
-                            rows="2"
-                            placeholder="Schrijf hier je voorbeeldzin..."
-                            maxlength="500"
-                        ></textarea>
-                        @error('example')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                    </div>
+                @error('source')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
 
-                    <div class="d-flex align-items-center justify-content-between gap-2">
-                        <button
-                            wire:click="submit"
-                            wire:loading.attr="disabled"
-                            class="btn shadow-sm btn-sm btn-success"
-                        >
-                            <span wire:loading.remove wire:target="submit">
-                                <x-heroicon-s-paper-airplane class="icon me-1"/> Indienen
-                            </span>
-                            <span wire:loading wire:target="submit">
-                                <span class="spinner-border spinner-border-sm me-1"></span> Bezig...
-                            </span>
-                        </button>
-                    </div>
+            <div class="col-12 mb-2">
+                <label for="example" class="visually-hidden-focusable">Voorbeeldzin</label>
+
+                <textarea
+                    id="example"
+                    wire:model="example"
+                    class="form-control bg-white form-control-sm @error('example') is-invalid @enderror"
+                    rows="2"
+                    placeholder="Schrijf hier je voorbeeldzin..."
+                    maxlength="500"
+                ></textarea>
+
+                @error('example')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
                 </div>
-            @else
-                <span class="text-muted fst-italic">
-                    <x-heroicon-s-exclamation-triangle class="icon me-1"/>
-                    Om voorbeeldzinnen toe te voegen moet je <a href="{{ route('login') }}">Aangemeld</a> zijn.
-                </span>
-            @endauth
+
+                <div class="d-flex align-items-center justify-content-between gap-2">
+                    <button
+                        wire:click="submit"
+                        wire:loading.attr="disabled"
+                        class="btn shadow-sm btn-sm btn-success"
+                    >
+
+                    <span wire:loading.remove wire:target="submit">
+                        <x-heroicon-s-paper-airplane class="icon me-1"/> Indienen
+                    </span>
+                    <span wire:loading wire:target="submit">
+                        <span class="spinner-border spinner-border-sm me-1"></span> Bezig...
+                    </span>
+                </button>
+            </div>
         </div>
-    @endif
+    @else
+        <span class="text-muted fst-italic">
+            <x-heroicon-s-exclamation-triangle class="icon me-1"/>
+            Om voorbeeldzinnen toe te voegen moet je <a href="{{ route('login') }}">Aangemeld</a> zijn.
+        </span>
+    @endauth
 </div>


### PR DESCRIPTION
Fix voor de Livewire component dat voorbeeldzinnen indient. Het succesbericht verbergd niet langer het formulier volledig, maar wordt boven het formulier weergegeven zodat gebruikers meerdere voorbeeldzinnen kunnen indienen. 

### Wijzigingen 

- **Logica gejerstructureerd:** Het succesbericht staat nu in dezelfde container als het formulier/ 
- **Voorbeeldzin na submit blijft zichtbaar:** gebruikers hoeven niet meer weg te navigeren
- **HR separator:** tussen succesbericht en formulier zijn duidelijk gescheiden. 
- **Voorwaardelijke rendering:** 
  - Succesbericht toont zich alleen als `$submitted === true` is. 
  - Formulier blijft beschikbaar voor nieuwe indieningen 
 - **Betere formatting** 
 
 ps @Taalmiet Moet je nog denken aan zaken laat het maar weten